### PR TITLE
Add code to remove api key

### DIFF
--- a/deprecated-claude-app/backend/src/database/index.ts
+++ b/deprecated-claude-app/backend/src/database/index.ts
@@ -492,6 +492,10 @@ export class Database {
   async getUserApiKeys(userId: string): Promise<ApiKey[]> {
     return Array.from(this.apiKeys.values()).filter(key => key.userId === userId);
   }
+  
+  async deleteApiKey(keyId: string): Promise<boolean> {
+    return this.apiKeys.delete(keyId);
+  }
 
   // Conversation methods
   async createConversation(userId: string, title: string, model: string, systemPrompt?: string, settings?: any, format?: 'standard' | 'prefill', contextManagement?: any): Promise<Conversation> {

--- a/deprecated-claude-app/backend/src/routes/auth.ts
+++ b/deprecated-claude-app/backend/src/routes/auth.ts
@@ -177,10 +177,9 @@ export function authRouter(db: Database): Router {
       if (!req.userId) {
         return res.status(401).json({ error: 'Unauthorized' });
       }
-
-      // For now, just return success as delete is not implemented in the in-memory DB
-      // In a real implementation, you would delete the key from the database
-      res.json({ success: true });
+      const { id } = req.params;
+      const didRemove = db.deleteApiKey(id);
+      res.json({ success: didRemove });
     } catch (error) {
       console.error('Delete API key error:', error);
       res.status(500).json({ error: 'Internal server error' });


### PR DESCRIPTION
Adds code to remove API key when user requests it (previously on the server end, removing was just a stub so it was never removed), resolves https://github.com/anima-research/animachat/issues/1