### PR TITLE
Refactor db into per user append jsonl files for conversation data

### DIFF
--- a/deprecated-claude-app/backend/src/database/conversation-store.ts
+++ b/deprecated-claude-app/backend/src/database/conversation-store.ts
@@ -32,6 +32,12 @@ export class ConversationEventStore {
     async getWritableUserEventStore(userId: string) : Promise<EventStore> {
         const existing = this.mostRecentUserEventStores.get(userId);
         if (existing) {
+            const posOfUserId = this.mostRecentUserIds.indexOf(userId);
+            if (posOfUserId != -1) {
+                // move user to end of queue
+                this.mostRecentUserIds.splice(posOfUserId, 1);
+                this.mostRecentUserIds.push(userId);
+            }
             return existing;
         }
         const userEventStore = new EventStore(this.baseDir, this.getUserFileName(userId));

--- a/deprecated-claude-app/backend/src/database/conversation-store.ts
+++ b/deprecated-claude-app/backend/src/database/conversation-store.ts
@@ -1,0 +1,98 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { Event, EventStore } from './persistence.js';
+
+export interface ConversationEvents {
+  userId: string;
+  events: Array<Event>;
+}
+
+export class ConversationEventStore {
+    baseDir;
+    mostRecentUserIds: Array<string> = [];
+    mostRecentUserEventStores: Map<string, EventStore> = new Map();
+    // We hold handles only for most recently accessed users
+    // this is necessary because os can limit number of open files to 1024 or less
+    // (type ulimit -n to see the limit on your machine)
+    maxFilesOpened;
+    
+    constructor(baseDir = './data/conversations', maxFilesOpened = 100) {
+        this.baseDir = baseDir;
+        this.maxFilesOpened = maxFilesOpened;
+    }
+    async init() {
+        await fs.mkdir(this.baseDir, { recursive: true });
+    }
+    getUserFileName(userId : string) : string {
+        return `${userId}.json`;
+    }
+    async getWritableUserEventStore(userId: string) : Promise<EventStore> {
+        const existing = this.mostRecentUserEventStores.get(userId);
+        if (existing) {
+            return existing;
+        }
+        const userEventStore = new EventStore(this.baseDir, this.getUserFileName(userId));
+        await userEventStore.init();
+        this.mostRecentUserEventStores.set(userId, userEventStore);
+        this.mostRecentUserIds.push(userId);
+        await this.purgeOldUsers();
+        return userEventStore;
+    }
+
+    async purgeOldUsers() : Promise<void> {
+        while (this.mostRecentUserIds.length > this.maxFilesOpened) {
+            const purgedUserId = this.mostRecentUserIds.shift();
+            if (purgedUserId) {
+              const purgedUserEventStore : EventStore | undefined = this.mostRecentUserEventStores.get(purgedUserId);
+              await purgedUserEventStore?.close();
+              this.mostRecentUserEventStores.delete(purgedUserId);
+            }
+            else {
+              break;
+            }
+        }
+    }
+
+    async appendEvent(userId: string, event: Event) : Promise<void> {
+        const userEventStore : EventStore = await this.getWritableUserEventStore(userId);
+        await userEventStore.appendEvent(event);
+    }
+
+    async loadUserEvents(userId: string) {
+        const userEventStore = new EventStore(this.baseDir, this.getUserFileName(userId)); // doesn't require init for just calling loadEvents
+        return userEventStore.loadEvents();
+    }
+
+    async loadAllEvents() {
+        const events = new Array<ConversationEvents>();
+        let files = [];
+        try {
+            files = await fs.readdir(this.baseDir);
+        }
+        catch (error) {
+            if (error === 'ENOENT') {
+                return events; // none populated yet, that's okay, return empty array
+            }
+            throw error;
+        }
+        for (const fileName of files) {
+            if (!fileName.endsWith('.jsonl')) {
+                continue;
+            }
+            const userId = path.basename(fileName, '.jsonl');
+
+            const filePath = path.join(this.baseDir, fileName);
+            const userEventStore = new EventStore(this.baseDir, filePath); // doesn't require init for just calling loadEvents
+            events.push({ userId: userId, events: await userEventStore.loadEvents() })
+        }
+        return events;
+    }
+    async close() {
+        for (var closingUser of this.mostRecentUserIds) {
+            var closingUserEventStore = this.mostRecentUserEventStores.get(closingUser);
+            await closingUserEventStore?.close();
+            this.mostRecentUserEventStores.delete(closingUser);
+        }
+        this.mostRecentUserIds = [];
+    }
+}

--- a/deprecated-claude-app/backend/src/database/conversation-store.ts
+++ b/deprecated-claude-app/backend/src/database/conversation-store.ts
@@ -16,7 +16,7 @@ export class ConversationEventStore {
     // (type ulimit -n to see the limit on your machine)
     maxFilesOpened : number;
     
-    constructor(baseDir = './data/conversations', maxFilesOpened = 100) {
+    constructor(baseDir = './data/conversationDataPerUser', maxFilesOpened = 100) {
         this.baseDir = baseDir;
         this.maxFilesOpened = maxFilesOpened;
     }

--- a/deprecated-claude-app/backend/src/database/conversation-store.ts
+++ b/deprecated-claude-app/backend/src/database/conversation-store.ts
@@ -8,13 +8,13 @@ export interface ConversationEvents {
 }
 
 export class ConversationEventStore {
-    baseDir;
+    baseDir : string;
     mostRecentUserIds: string[] = [];
     mostRecentUserEventStores: Map<string, EventStore> = new Map();
     // We hold handles only for most recently accessed users
     // this is necessary because os can limit number of open files to 1024 or less
     // (type ulimit -n to see the limit on your machine)
-    maxFilesOpened;
+    maxFilesOpened : number;
     
     constructor(baseDir = './data/conversations', maxFilesOpened = 100) {
         this.baseDir = baseDir;

--- a/deprecated-claude-app/backend/src/database/conversation-store.ts
+++ b/deprecated-claude-app/backend/src/database/conversation-store.ts
@@ -26,7 +26,7 @@ export class ConversationEventStore {
     }
 
     getUserFileName(userId : string) : string {
-        return `${userId}.json`;
+        return `${userId}.jsonl`;
     }
 
     async getWritableUserEventStore(userId: string) : Promise<EventStore> {
@@ -74,8 +74,8 @@ export class ConversationEventStore {
             files = await fs.readdir(this.baseDir);
         }
         catch (error) {
-            if (error === 'ENOENT') {
-                return; // none populated yet, that's okay, return empty array
+            if ((error as NodeJS.ErrnoException)?.code === 'ENOENT') {
+              return; // none populated yet, that's okay, return empty array
             }
             throw error;
         }
@@ -84,9 +84,7 @@ export class ConversationEventStore {
                 continue;
             }
             const userId = path.basename(fileName, '.jsonl');
-
-            const filePath = path.join(this.baseDir, fileName);
-            const userEventStore = new EventStore(this.baseDir, filePath); // doesn't require init for just calling loadEvents
+            const userEventStore = new EventStore(this.baseDir, fileName); // doesn't require init for just calling loadEvents
             yield { userId: userId, events: await userEventStore.loadEvents() };
         }
     }

--- a/deprecated-claude-app/backend/src/database/index.ts
+++ b/deprecated-claude-app/backend/src/database/index.ts
@@ -47,6 +47,7 @@ export class Database {
     if (this.initialized) return;
     
     await this.eventStore.init();
+    await this.conversationEventStore.init();
     
     // Load all events and rebuild state
     const events = await this.eventStore.loadEvents();

--- a/deprecated-claude-app/backend/src/database/index.ts
+++ b/deprecated-claude-app/backend/src/database/index.ts
@@ -1183,7 +1183,7 @@ export class Database {
     
     const conversation = this.conversations.get(participant.conversationId);
     if (conversation) {
-      await this.logConversationEvent(participant.conversationId, 'participant_deleted', { participantId, conversationId: participant.conversationId });
+      await this.logConversationEvent(conversation.userId, 'participant_deleted', { participantId, conversationId: participant.conversationId });
     }
 
     return true;
@@ -1218,7 +1218,7 @@ export class Database {
     // Store event
     const conversation = this.conversations.get(conversationId);
     if (conversation) {
-      this.logConversationEvent(conversation.userId, 'metrics_added', { conversationId, metrics });
+      await this.logConversationEvent(conversation.userId, 'metrics_added', { conversationId, metrics });
     }
   }
   

--- a/deprecated-claude-app/backend/src/database/index.ts
+++ b/deprecated-claude-app/backend/src/database/index.ts
@@ -55,6 +55,18 @@ export class Database {
     for (const event of events) {
       await this.replayEvent(event);
     }
+
+    console.log(`Loading conversation events from disk...`);
+
+    var numUserEvents = 0;
+    for await (const {userId, events} of this.conversationEventStore.loadAllEvents()) {
+      for (const event of events) {
+        numUserEvents += 1;
+        await this.replayEvent(event);
+      }
+    }
+
+    console.log(`Loaded ${numUserEvents} conversation events from disk.`);
     
     // Create test user if no users exist
     if (this.users.size === 0) {

--- a/deprecated-claude-app/backend/src/database/persistence.ts
+++ b/deprecated-claude-app/backend/src/database/persistence.ts
@@ -11,8 +11,8 @@ export class EventStore {
   private filePath: string;
   private writeStream: fs.FileHandle | null = null;
   
-  constructor(dataDir: string = './data') {
-    this.filePath = path.join(dataDir, 'events.jsonl');
+  constructor(dataDir: string = './data', fileName: string = 'events.jsonl') {
+    this.filePath = path.join(dataDir, fileName);
   }
   
   async init(): Promise<void> {


### PR DESCRIPTION
This makes one EventStore for each user, stored at

```
./data/conversationDataPerUser/{userId}.jsonl
```

which will hold conversation data and conversation settings.

API Key and user settings are still stored in the old ('main') EventStore as usual.

This is backwards compatible with existing db, so no manual migration needed.

Replaying back events will always happen in the correct order based on timestamp. Unfortunately this does require loading all events into memory first and sorting them by timestamp, not a great solution to this without significant extra complexity. Probably when "all events in memory" becomes an issue we should switch to a real DB.

This will not manually move old conversation events into the new db, old conversation data events will simply stay in the main db (the code doesn't mind that). A future PR could do this conversation if needed.