### PR TITLE
Fix contentBlocks replay, NaN prevention, and diagnostics

### DIFF
--- a/deprecated-claude-app/backend/src/services/anthropic.ts
+++ b/deprecated-claude-app/backend/src/services/anthropic.ts
@@ -328,6 +328,14 @@ export class AnthropicService {
             lastChars: fullResponse.slice(-100)
           });
           
+          // DIAGNOSTIC: Detect when thinking happened but no text content followed
+          const hasThinkingBlocks = contentBlocks.some((b: any) => b.type === 'thinking' || b.type === 'redacted_thinking');
+          if (hasThinkingBlocks && fullResponse.length === 0) {
+            console.warn(`[Anthropic API] ⚠️ DIAGNOSTIC: Thinking blocks present but NO text content generated!`);
+            console.warn(`[Anthropic API] ⚠️ Stop reason: ${stopReason}, Usage: input=${usage.input_tokens}, output=${usage.output_tokens}`);
+            console.warn(`[Anthropic API] ⚠️ This may be a token budget issue - thinking may have consumed all output tokens.`);
+          }
+          
           // Calculate cost savings
           const costSaved = this.calculateCacheSavings(requestParams.model, cacheMetrics.cacheReadInputTokens);
           

--- a/deprecated-claude-app/backend/src/services/enhanced-inference.ts
+++ b/deprecated-claude-app/backend/src/services/enhanced-inference.ts
@@ -382,12 +382,12 @@ export class EnhancedInferenceService {
           // - cacheCreationInputTokens = tokens written to cache
           // - cacheReadInputTokens = tokens read from cache
           // Total prompt = fresh + cache_creation + cache_read
-          const freshTokens = actualUsage.inputTokens;
+          const freshTokens = actualUsage.inputTokens ?? 0; // Defensive default to prevent NaN
           const cacheCreation = actualUsage.cacheCreationInputTokens || 0;
           const cacheRead = actualUsage.cacheReadInputTokens || 0;
           
           inputTokens = freshTokens + cacheCreation + cacheRead; // TOTAL input
-          outputTokens = actualUsage.outputTokens;
+          outputTokens = actualUsage.outputTokens ?? 0; // Defensive default
           // Cache size: creation OR read (whichever is non-zero shows current cache size)
           cachedTokens = cacheRead > 0 ? cacheRead : cacheCreation;
           cacheHit = cacheRead > 0;

--- a/deprecated-claude-app/backend/src/services/gemini.ts
+++ b/deprecated-claude-app/backend/src/services/gemini.ts
@@ -330,11 +330,11 @@ export class GeminiService {
                 }
               }
               
-              // Extract usage
+              // Extract usage (with defensive defaults to prevent NaN)
               if (chunk.usageMetadata) {
                 usage = {
-                  inputTokens: chunk.usageMetadata.promptTokenCount,
-                  outputTokens: chunk.usageMetadata.candidatesTokenCount,
+                  inputTokens: chunk.usageMetadata.promptTokenCount ?? 0,
+                  outputTokens: chunk.usageMetadata.candidatesTokenCount ?? 0,
                 };
               }
             } catch (parseError) {
@@ -347,6 +347,12 @@ export class GeminiService {
       // Log thinking completion
       if (hasThinkingStarted) {
         console.log(`[Gemini API] 🧠 Thinking complete: ${thinkingContent.length} chars`);
+      }
+      
+      // DIAGNOSTIC: Detect when thinking happened but no text content followed
+      if (hasThinkingStarted && fullContent.length === 0) {
+        console.warn(`[Gemini API] ⚠️ DIAGNOSTIC: Thinking content received (${thinkingContent.length} chars) but NO text content generated!`);
+        console.warn(`[Gemini API] ⚠️ This may be a token budget issue or API limitation. Stream ended after ${chunkCount} chunks.`);
       }
       
       // Add text content block if we have text (with thought_signature if present)


### PR DESCRIPTION
## Summary

- **ContentBlocks replay fix**: Critical bug where thinking blocks and images disappeared after server restart. The tree structure builder wasn't restoring `contentBlocks` from events.

- **NaN prevention**: Added defensive `?? 0` defaults in `gemini.ts` and `enhanced-inference.ts` to prevent NaN tokens from corrupting metrics display.

- **Diagnostic logging**: Added warnings when thinking blocks are present but no text content was generated. This helps debug the "thinking but no response" issue.

- **Admin diagnostic endpoint**: New `/api/admin/conversation-size/:id` to investigate browser-crashing large conversations (big base64 images).

## Test plan

- [ ] Restart server with existing thinking-block conversations - should now restore properly
- [ ] Check Gemini/Claude responses with thinking - should not show NaN
- [ ] Monitor logs for `⚠️ DIAGNOSTIC` warnings when thinking-without-text occurs
- [ ] Test admin endpoint on known problematic conversation