### PR TITLE
Add blind mode for multi-user conversations

### DIFF
--- a/deprecated-claude-app/README.md
+++ b/deprecated-claude-app/README.md
@@ -12,6 +12,7 @@ A web application that allows users to continue using deprecated Claude models t
 - **API Key Management**: Use your own AWS Bedrock credentials or pay at cost
 - **Export/Import**: Full conversation backup and restore functionality
 - **Modern UI**: Dark mode support with Vuetify Material Design
+- **Blind Mode**: Multi-user conversations where participants can't see each other's messages, but Claude sees everything for full context
 
 ## Architecture
 

--- a/deprecated-claude-app/backend/src/utils/message-visibility.ts
+++ b/deprecated-claude-app/backend/src/utils/message-visibility.ts
@@ -1,0 +1,85 @@
+import { Message } from '@deprecated-claude/shared';
+
+/**
+ * Check if a single message should be visible to a user in blind mode.
+ */
+function isMessageVisibleToUser(
+  message: Message,
+  userId: string,
+  visibility: 'normal' | 'blind' | undefined
+): boolean {
+  // Normal mode - always visible
+  if (!visibility || visibility === 'normal') {
+    return true;
+  }
+
+  const activeBranch = message.branches.find(b => b.id === message.activeBranchId);
+  if (!activeBranch) return false;
+
+  // Assistant messages always visible
+  if (activeBranch.role === 'assistant') {
+    return true;
+  }
+
+  // User's own messages visible
+  return activeBranch.sentByUserId === userId;
+}
+
+/**
+ * Create a redacted version of a message for blind mode.
+ */
+function redactMessage(message: Message): Message & { blindModeRedacted: boolean } {
+  const redactedBranches = message.branches.map(branch => ({
+    ...branch,
+    content: '',
+    contentBlocks: [],
+    blindModeRedacted: true,
+  }));
+
+  return {
+    ...message,
+    branches: redactedBranches,
+    blindModeRedacted: true,
+  } as Message & { blindModeRedacted: boolean };
+}
+
+/**
+ * Transform a message for a specific user in blind mode.
+ * Returns the full message if visible, or a redacted version if hidden.
+ * Used for both REST API and WebSocket broadcasts.
+ */
+export function transformMessageForUser(
+  message: Message,
+  userId: string,
+  visibility: 'normal' | 'blind' | undefined
+): Message {
+  if (isMessageVisibleToUser(message, userId, visibility)) {
+    return message;
+  }
+  return redactMessage(message);
+}
+
+/**
+ * Apply blind mode redactions to an array of messages.
+ * Used for REST API responses (GET /messages).
+ *
+ * In 'blind' mode, users can only see:
+ * - Their own messages (sentByUserId matches)
+ * - All assistant messages (Claude sees everything, users see all responses)
+ *
+ * Hidden messages are replaced with redacted placeholders so users know
+ * something exists there, and the tree structure remains intact.
+ */
+export function applyBlindModeRedactions(
+  messages: Message[],
+  userId: string,
+  visibility: 'normal' | 'blind' | undefined
+): Message[] {
+  // Normal mode or undefined - no filtering
+  if (!visibility || visibility === 'normal') {
+    return messages;
+  }
+
+  // Blind mode - transform each message
+  return messages.map(message => transformMessageForUser(message, userId, visibility));
+}

--- a/deprecated-claude-app/frontend/src/components/ConversationSettingsDialog.vue
+++ b/deprecated-claude-app/frontend/src/components/ConversationSettingsDialog.vue
@@ -182,6 +182,23 @@
               </v-tooltip>
             </template>
           </v-checkbox>
+
+          <v-checkbox
+            v-model="blindMode"
+            label="Blind mode (users can't see each other's messages)"
+            density="compact"
+            class="mt-2"
+          >
+            <template v-slot:append>
+              <v-tooltip location="top" open-on-click open-on-focus max-width="300">
+                <template v-slot:activator="{ props }">
+                  <v-icon v-bind="props" size="small" class="tooltip-icon">mdi-help-circle-outline</v-icon>
+                </template>
+                In blind mode, users can only see their own messages and all assistant responses.
+                Other users' messages are hidden, but the AI can see everything.
+              </v-tooltip>
+            </template>
+          </v-checkbox>
         </div>
         
         <div v-if="selectedModel && settings.format === 'standard'">
@@ -648,6 +665,7 @@ const prefillUserMessageContent = ref('<cmd>cat untitled.log</cmd>');
 const cliModeEnabled = ref(true);
 const cliModeThreshold = ref(10);
 const combineConsecutiveMessages = ref(true);
+const blindMode = ref(false);
 
 const formatOptions = [
   {
@@ -811,7 +829,10 @@ watch(() => props.conversation, async (conversation) => {
     
     // Load combine consecutive messages setting
     combineConsecutiveMessages.value = conversation.combineConsecutiveMessages ?? true;
-    
+
+    // Load blind mode setting
+    blindMode.value = conversation.visibility === 'blind';
+
     // Load participants if in multi-participant mode
     await loadParticipants();
   }
@@ -1054,7 +1075,8 @@ function save() {
     contextManagement,
     prefillUserMessage,
     cliModePrompt,
-    combineConsecutiveMessages: combineConsecutiveMessages.value
+    combineConsecutiveMessages: combineConsecutiveMessages.value,
+    visibility: blindMode.value ? 'blind' : 'normal'
   });
   
   // If in multi-participant mode, emit participants for parent to update

--- a/deprecated-claude-app/frontend/src/components/MessageComponent.vue
+++ b/deprecated-claude-app/frontend/src/components/MessageComponent.vue
@@ -26,6 +26,15 @@
     />
   </div>
 
+  <!-- Blind mode redacted messages render as compact system status messages -->
+  <div
+    v-else-if="isBlindModeRedacted"
+    class="blind-mode-status-marker"
+  >
+    <v-icon size="14" icon="mdi-eye-off" class="mr-1" />
+    <span>Message hidden (blind mode)</span>
+  </div>
+
   <!-- Regular messages -->
   <div
     v-else
@@ -443,9 +452,9 @@
       </div>
       
       <!-- Message content or edit mode -->
-      <div 
-        v-if="!isEditing" 
-        :class="['message-content', { 'monospace-mode': isMonospace }]" 
+      <div
+        v-if="!isEditing"
+        :class="['message-content', { 'monospace-mode': isMonospace }]"
         v-html="renderedContent"
         @contextmenu="handleContentContextMenu"
       />
@@ -1014,6 +1023,11 @@ const currentBranch = computed(() => {
 // Check if this message is a post-hoc operation
 const isPostHocOperation = computed(() => {
   return !!currentBranch.value?.postHocOperation;
+});
+
+// Check if this message is redacted due to blind mode
+const isBlindModeRedacted = computed(() => {
+  return !!(props.message as any).blindModeRedacted || !!(currentBranch.value as any)?.blindModeRedacted;
 });
 
 // Truncate text for display
@@ -2412,6 +2426,19 @@ watch(() => currentBranch.value.id, async () => {
 
 .prefix-history-entry.bg-grey-darken-3 {
   border-left-color: rgba(var(--v-theme-primary), 0.7);
+}
+
+/* Blind mode status marker - centered inline system message */
+.blind-mode-status-marker {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px 12px;
+  margin: 8px auto;
+  font-size: 0.75rem;
+  font-style: italic;
+  color: rgba(var(--v-theme-on-surface), 0.4);
+  opacity: 0.7;
 }
 </style>
 

--- a/deprecated-claude-app/shared/src/types.ts
+++ b/deprecated-claude-app/shared/src/types.ts
@@ -592,7 +592,8 @@ export const ConversationSchema = z.object({
     enabled: z.boolean().default(true),
     messageThreshold: z.number().default(10) // Apply CLI prompt for conversations under this many messages
   }).optional(),
-  combineConsecutiveMessages: z.boolean().default(true).optional() // Combine consecutive same-role messages when building context (default: true)
+  combineConsecutiveMessages: z.boolean().default(true).optional(), // Combine consecutive same-role messages when building context (default: true)
+  visibility: z.enum(['normal', 'blind']).default('normal').optional() // Blind mode: users can't see each other's messages, but Claude sees all
 });
 
 export type Conversation = z.infer<typeof ConversationSchema>;


### PR DESCRIPTION
## Summary
- Add "blind mode" visibility setting for conversations where users can't see each other's messages
- Claude still sees all messages for full context, but users only see their own messages + all assistant responses
- Hidden messages appear as compact IRC-style status markers ("Message hidden (blind mode)")

## Implementation
- Added `visibility` field to conversation schema (`'normal' | 'blind'`)
- Created `message-visibility.ts` with redaction logic shared by REST and WebSocket
- Updated `broadcastToRoom` to support per-user message transformation
- Added UI toggle in conversation settings dialog

## Test plan
- [X] Enable blind mode on a multi-user conversation
- [X] Verify User A cannot see User B's messages (shows redacted placeholder)
- [X] Verify both users can see all assistant responses
- [X] Verify real-time updates work (new messages appear as redacted in real-time)
- [X] Verify page reload shows same redacted state

<img width="2879" height="1599" alt="image" src="https://github.com/user-attachments/assets/23ffd841-82f9-4f26-8e22-aea31c5752b8" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)