### PR TITLE
fix: allow unlimited invites to be claimed more than once

### DIFF
--- a/deprecated-claude-app/backend/src/database/index.ts
+++ b/deprecated-claude-app/backend/src/database/index.ts
@@ -714,8 +714,8 @@ export class Database {
       return { valid: false, error: 'This invite has reached its maximum uses' };
     }
 
-    // Legacy check for old single-use invites without useCount
-    if (invite.maxUses === undefined && invite.claimedBy) {
+    // Legacy check for old single-use invites that predate the useCount system
+    if (invite.maxUses === undefined && invite.claimedBy && invite.useCount === undefined) {
       return { valid: false, error: 'This invite has already been used' };
     }
 


### PR DESCRIPTION
Legacy validation guard was rejecting all invites with maxUses undefined after first claim. Narrowed the check to only apply to pre-useCount invites by also requiring useCount === undefined.