### PR TITLE
fix: render LaTeX correctly with currency-safe inline math

### DIFF
--- a/deprecated-claude-app/frontend/src/components/MessageComponent.vue
+++ b/deprecated-claude-app/frontend/src/components/MessageComponent.vue
@@ -886,7 +886,7 @@ import { marked } from 'marked';
 import DOMPurify from 'dompurify';
 import type { Message, Participant } from '@deprecated-claude/shared';
 import { getModelColor } from '@/utils/modelColors';
-import { renderLatex, KATEX_ALLOWED_TAGS, KATEX_ALLOWED_ATTRS } from '@/utils/latex';
+import { extractMath, restoreMath, KATEX_ALLOWED_TAGS, KATEX_ALLOWED_ATTRS } from '@/utils/latex';
 import { api } from '@/services/api';
 import { useStore } from '@/store';
 import { getParticipantAvatarUrl, getAvatarColor, loadAvatarPacks } from '@/utils/avatars';
@@ -1419,7 +1419,16 @@ const renderedContent = computed(() => {
     inlineCode.push(match);
     return `__INLINE_CODE_${index}__`;
   });
-  
+
+  // Extract LaTeX math regions BEFORE markdown runs. CommonMark backslash
+  // escapes (\(, \), \[, \]) would otherwise be consumed by marked.parse,
+  // destroying the math delimiters before KaTeX ever sees them. The returned
+  // placeholders are plain alphanumerics, so they survive markdown unchanged.
+  // Code blocks are already placeholdered above, so math inside ``` blocks
+  // is not affected.
+  const { text: contentAfterMath, rendered: renderedMath } = extractMath(content);
+  content = contentAfterMath;
+
   // Escape HTML/XML tags that aren't in code blocks
   // This prevents raw HTML from being rendered but preserves it visually
   content = content.replace(/</g, '&lt;').replace(/>/g, '&gt;');
@@ -1467,9 +1476,10 @@ const renderedContent = computed(() => {
   if (html instanceof Promise) {
     html = ''; // Fallback, but this shouldn't happen with sync parse
   }
-  
-  // Render LaTeX after markdown (so LaTeX in code blocks is protected)
-  html = renderLatex(html as string);
+
+  // Substitute rendered KaTeX HTML back in for the math placeholders we
+  // extracted before markdown ran.
+  html = restoreMath(html as string, renderedMath);
   
   // Convert leading/trailing spaces to non-breaking spaces to preserve them
   const leadingNbsp = leadingSpaces.replace(/ /g, '&nbsp;').replace(/\n/g, '<br>');

--- a/deprecated-claude-app/frontend/src/components/SharedMessageComponent.vue
+++ b/deprecated-claude-app/frontend/src/components/SharedMessageComponent.vue
@@ -85,7 +85,7 @@ import { ref, computed } from 'vue';
 import { marked } from 'marked';
 import DOMPurify from 'dompurify';
 import { getModelColor } from '@/utils/modelColors';
-import { renderLatex, KATEX_ALLOWED_TAGS, KATEX_ALLOWED_ATTRS } from '@/utils/latex';
+import { extractMath, restoreMath, KATEX_ALLOWED_TAGS, KATEX_ALLOWED_ATTRS } from '@/utils/latex';
 import { api } from '@/services/api';
 import 'katex/dist/katex.min.css';
 
@@ -165,11 +165,13 @@ const renderedContent = computed(() => {
     gfm: true      // GitHub Flavored Markdown
   });
   
-  // Markdown + LaTeX rendering
+  // Markdown + LaTeX rendering — extract math BEFORE markdown so its
+  // backslash-escaped delimiters (\(, \[) survive CommonMark escape rules.
+  // See utils/latex.ts for details.
   try {
-    let html = marked.parse ? marked.parse(content) : (marked as any)(content);
-    // Render LaTeX after markdown
-    html = renderLatex(html as string);
+    const { text: contentAfterMath, rendered: renderedMath } = extractMath(content);
+    let html = marked.parse ? marked.parse(contentAfterMath) : (marked as any)(contentAfterMath);
+    html = restoreMath(html as string, renderedMath);
     return DOMPurify.sanitize(html, {
       ALLOWED_TAGS: [
         'p', 'br', 'strong', 'em', 'u', 's', 'code', 'pre',

--- a/deprecated-claude-app/frontend/src/utils/latex.ts
+++ b/deprecated-claude-app/frontend/src/utils/latex.ts
@@ -2,100 +2,154 @@ import katex from 'katex';
 
 /**
  * Render LaTeX in content.
- * Supports:
- * - Display math: $$ ... $$ or \[ ... \]
- * - Inline math: $ ... $ or \( ... \)
- * 
- * Returns HTML with rendered LaTeX.
+ *
+ * Supports four math delimiters:
+ *   - Display: $$...$$  and  \[...\]
+ *   - Inline:  $...$    and  \(...\)
+ *
+ * IMPORTANT ORDERING: LaTeX must be extracted from the source text BEFORE
+ * markdown parses it, because CommonMark backslash-escapes (`\(`, `\)`, `\[`,
+ * `\]`) get consumed by marked.parse() — turning `\(n \ge 1\)` into `(n \ge 1)`
+ * before KaTeX can ever see it.
+ *
+ * Pipeline:
+ *   1. extractMath(content) → replaces math regions with placeholder tokens
+ *      and returns the substituted text plus a map of rendered HTML.
+ *   2. marked.parse() runs on the substituted text. Placeholders survive
+ *      because they're plain alphanumerics.
+ *   3. restoreMath(html, map) substitutes the rendered HTML back in.
+ *
+ * Currency-safety: the `$...$` inline matcher is intentionally strict —
+ * it requires a non-digit, non-whitespace character immediately inside both
+ * delimiters and refuses to match if a digit follows the closing `$`. So
+ * `$100. Strike at $110, premium $3` stays as text. Math intended as inline
+ * math should use `\(...\)` (which is what Claude and GPT typically emit
+ * anyway) or display form `$$...$$`.
  */
-export function renderLatex(content: string): string {
-  // Skip if no math delimiters are present (optimization)
-  if (!content.includes('$') && !content.includes('\\(') && !content.includes('\\[')) {
-    return content;
+
+interface KatexOptions {
+  throwOnError: boolean;
+  strict: boolean;
+  output: 'html';
+  displayMode: boolean;
+}
+
+const BASE_OPTIONS: Omit<KatexOptions, 'displayMode'> = {
+  throwOnError: false,
+  strict: false, // Suppress warnings about unicode box-drawing chars etc.
+  output: 'html',
+};
+
+// Placeholder tokens use a private-use unicode prefix so they can't appear
+// in user content, then plain ASCII so markdown won't transform them.
+const PLACEHOLDER_PREFIX = 'ARCMATH';
+const PLACEHOLDER_SUFFIX = '';
+const PLACEHOLDER_RE = new RegExp(
+  `${PLACEHOLDER_PREFIX}(\\d+)${PLACEHOLDER_SUFFIX}`,
+  'g',
+);
+
+function renderToHtml(latex: string, displayMode: boolean, original: string): string {
+  try {
+    return katex.renderToString(latex.trim(), { ...BASE_OPTIONS, displayMode });
+  } catch (err) {
+    console.warn(`[latex] render error (${displayMode ? 'display' : 'inline'}):`, err);
+    // Fall back to the unrendered original so the user sees their source.
+    return original;
   }
-  
-  let result = content;
-  
-  // Common KaTeX options - strict: false suppresses warnings about unknown Unicode chars
-  const katexOptions = {
-    throwOnError: false,
-    strict: false, // Suppress warnings about box-drawing chars, etc.
-    output: 'html' as const
-  };
-  
-  // Display math: $$ ... $$ (must be processed before single $)
-  result = result.replace(/\$\$([\s\S]*?)\$\$/g, (match, latex) => {
-    try {
-      return katex.renderToString(latex.trim(), {
-        ...katexOptions,
-        displayMode: true
-      });
-    } catch (e) {
-      console.warn('LaTeX render error (display):', e);
-      return match; // Return original on error
-    }
-  });
-  
-  // Display math: \[ ... \]
-  result = result.replace(/\\\[([\s\S]*?)\\\]/g, (match, latex) => {
-    try {
-      return katex.renderToString(latex.trim(), {
-        ...katexOptions,
-        displayMode: true
-      });
-    } catch (e) {
-      console.warn('LaTeX render error (display):', e);
-      return match;
-    }
-  });
-  
-  // Inline math: $ ... $ (but not $$ or escaped \$)
-  // Use negative lookbehind to avoid matching escaped $ or $$
-  result = result.replace(/(?<!\$)\$(?!\$)((?:[^$\\]|\\.)+?)\$/g, (match, latex) => {
-    try {
-      return katex.renderToString(latex.trim(), {
-        ...katexOptions,
-        displayMode: false
-      });
-    } catch (e) {
-      console.warn('LaTeX render error (inline):', e);
-      return match;
-    }
-  });
-  
-  // Inline math: \( ... \)
-  result = result.replace(/\\\(([\s\S]*?)\\\)/g, (match, latex) => {
-    try {
-      return katex.renderToString(latex.trim(), {
-        ...katexOptions,
-        displayMode: false
-      });
-    } catch (e) {
-      console.warn('LaTeX render error (inline):', e);
-      return match;
-    }
-  });
-  
-  return result;
 }
 
 /**
- * List of tags that KaTeX generates which need to be allowed in DOMPurify
+ * Strict inline `$...$` matcher.
+ *
+ * Rules (any one failure means the candidate is treated as plain text):
+ *   - Opening `$` must be followed by a non-digit, non-whitespace character.
+ *   - Closing `$` must be preceded by a non-whitespace character.
+ *   - Closing `$` must not be followed by a digit.
+ *   - No newlines inside the match (would suggest paragraph break, not math).
+ *   - Not part of `$$` (handled separately as display math).
+ *
+ * Examples:
+ *   ✓  `$x + 1$`           — letter follows opening, no digit issues
+ *   ✓  `$\\frac{1}{2}$`    — backslash follows opening
+ *   ✗  `$100`              — digit follows opening
+ *   ✗  `strike $110, $3`   — digit follows opening
+ *   ✗  `cost is $ 50 $`    — whitespace follows opening
+ */
+const INLINE_DOLLAR_RE =
+  /(?<!\$)\$(?!\$)([^\s\d$][^\n$]*?[^\s$])\$(?!\d)/g;
+
+/**
+ * Extract math regions from raw model output, replacing them with placeholder
+ * tokens. Order matters: longest/most-specific delimiters first so we don't
+ * partially consume display math.
+ */
+export function extractMath(content: string): { text: string; rendered: string[] } {
+  const rendered: string[] = [];
+  let text = content;
+
+  const replace = (re: RegExp, displayMode: boolean) => {
+    text = text.replace(re, (match, body) => {
+      const html = renderToHtml(body, displayMode, match);
+      const idx = rendered.length;
+      rendered.push(html);
+      return `${PLACEHOLDER_PREFIX}${idx}${PLACEHOLDER_SUFFIX}`;
+    });
+  };
+
+  // Order: $$ first (greediest), then \[ \], then strict $, then \( \).
+  // Display math: $$ ... $$
+  replace(/\$\$([\s\S]+?)\$\$/g, true);
+  // Display math: \[ ... \]
+  replace(/\\\[([\s\S]+?)\\\]/g, true);
+  // Inline math: \( ... \)   — must run BEFORE $...$ so that escapes inside
+  // \(...\) aren't grabbed by the dollar matcher.
+  replace(/\\\(([\s\S]+?)\\\)/g, false);
+  // Inline math: $ ... $   (currency-safe; see INLINE_DOLLAR_RE comment)
+  replace(INLINE_DOLLAR_RE, false);
+
+  return { text, rendered };
+}
+
+/**
+ * Substitute the rendered KaTeX HTML back in for placeholder tokens.
+ * Safe to call on either raw text or post-markdown HTML.
+ */
+export function restoreMath(html: string, rendered: string[]): string {
+  return html.replace(PLACEHOLDER_RE, (_, idx) => rendered[Number(idx)] ?? '');
+}
+
+/**
+ * Legacy single-pass API.
+ *
+ * Kept for backwards compatibility (in case any caller still depends on the
+ * old "render math in-place over an HTML string" behavior), but DO NOT use
+ * for new code: it runs after markdown has already stripped `\(`/`\[`
+ * delimiters. Use `extractMath` + `restoreMath` around `marked.parse` instead.
+ *
+ * @deprecated Use `extractMath` / `restoreMath` around markdown parsing.
+ */
+export function renderLatex(content: string): string {
+  if (!content.includes('$') && !content.includes('\\(') && !content.includes('\\[')) {
+    return content;
+  }
+  const { text, rendered } = extractMath(content);
+  return restoreMath(text, rendered);
+}
+
+/**
+ * KaTeX-generated tags that need to be allowed through DOMPurify so the
+ * rendered math survives sanitization.
  */
 export const KATEX_ALLOWED_TAGS = [
   'span', 'math', 'semantics', 'mrow', 'mi', 'mo', 'mn', 'msup', 'msub',
   'mfrac', 'mover', 'munder', 'munderover', 'msqrt', 'mroot', 'mtable',
-  'mtr', 'mtd', 'mtext', 'mspace', 'annotation', 'svg', 'line', 'path'
+  'mtr', 'mtd', 'mtext', 'mspace', 'annotation', 'svg', 'line', 'path',
 ];
 
-/**
- * List of attributes that KaTeX uses
- */
+/** Attributes KaTeX emits. */
 export const KATEX_ALLOWED_ATTRS = [
   'class', 'style', 'aria-hidden', 'encoding', 'xmlns', 'xlink:href',
   'viewBox', 'width', 'height', 'fill', 'stroke', 'stroke-width',
-  'd', 'x', 'y', 'x1', 'x2', 'y1', 'y2'
+  'd', 'x', 'y', 'x1', 'x2', 'y1', 'y2',
 ];
-
-
-

--- a/deprecated-claude-app/frontend/src/utils/latex.ts
+++ b/deprecated-claude-app/frontend/src/utils/latex.ts
@@ -16,7 +16,8 @@ import katex from 'katex';
  *   1. extractMath(content) → replaces math regions with placeholder tokens
  *      and returns the substituted text plus a map of rendered HTML.
  *   2. marked.parse() runs on the substituted text. Placeholders survive
- *      because they're plain alphanumerics.
+ *      because they sit between Private Use Area unicode brackets that no
+ *      markdown rule touches.
  *   3. restoreMath(html, map) substitutes the rendered HTML back in.
  *
  * Currency-safety: the `$...$` inline matcher is intentionally strict —
@@ -40,12 +41,21 @@ const BASE_OPTIONS: Omit<KatexOptions, 'displayMode'> = {
   output: 'html',
 };
 
-// Placeholder tokens use a private-use unicode prefix so they can't appear
-// in user content, then plain ASCII so markdown won't transform them.
-const PLACEHOLDER_PREFIX = 'ARCMATH';
-const PLACEHOLDER_SUFFIX = '';
+// Placeholder tokens use a Private Use Area unicode bracket around an ASCII
+// body. The PUA characters (U+E000 / U+E001) are not assigned to any script,
+// effectively never appear in normal text or model output, and aren't
+// markdown-special — so (a) collision risk with real content is effectively
+// zero, and (b) marked.parse() passes them through unchanged. The body
+// stays ASCII (`ARCMATH<N>`) so the placeholder is still grep-friendly in
+// dev. The trailing PUA bracket also disambiguates adjacent multi-digit
+// indices, which a greedy `\d+` regex would otherwise tangle (e.g.
+// `ARCMATH1ARCMATH23` could be misparsed as a single match).
+const PLACEHOLDER_OPEN = '';
+const PLACEHOLDER_CLOSE = '';
+const PLACEHOLDER_PREFIX = `${PLACEHOLDER_OPEN}ARCMATH`;
+const PLACEHOLDER_SUFFIX = PLACEHOLDER_CLOSE;
 const PLACEHOLDER_RE = new RegExp(
-  `${PLACEHOLDER_PREFIX}(\\d+)${PLACEHOLDER_SUFFIX}`,
+  `${PLACEHOLDER_OPEN}ARCMATH(\\d+)${PLACEHOLDER_CLOSE}`,
   'g',
 );
 
@@ -69,15 +79,22 @@ function renderToHtml(latex: string, displayMode: boolean, original: string): st
  *   - No newlines inside the match (would suggest paragraph break, not math).
  *   - Not part of `$$` (handled separately as display math).
  *
+ * The capture group is an alternation so both single-char (`$n$`, `$x$`,
+ * `$k$` — very common in mathematical prose) and multi-char (`$x + 1$`,
+ * `$\frac{a}{b}$`) bodies match. The original single-branch regex
+ * `[^\s\d$][^\n$]*?[^\s$]` required at least two distinct characters and
+ * silently dropped single-letter inline math.
+ *
  * Examples:
- *   ✓  `$x + 1$`           — letter follows opening, no digit issues
- *   ✓  `$\\frac{1}{2}$`    — backslash follows opening
- *   ✗  `$100`              — digit follows opening
- *   ✗  `strike $110, $3`   — digit follows opening
- *   ✗  `cost is $ 50 $`    — whitespace follows opening
+ *   ✓  `$n$`              — single letter
+ *   ✓  `$x + 1$`          — letter follows opening, no digit issues
+ *   ✓  `$\frac{1}{2}$`    — backslash follows opening
+ *   ✗  `$100`             — digit follows opening
+ *   ✗  `strike $110, $3`  — digit follows opening
+ *   ✗  `cost is $ 50 $`   — whitespace follows opening
  */
 const INLINE_DOLLAR_RE =
-  /(?<!\$)\$(?!\$)([^\s\d$][^\n$]*?[^\s$])\$(?!\d)/g;
+  /(?<!\$)\$(?!\$)([^\s\d$][^\n$]*?[^\s$]|[^\s\d$])\$(?!\d)/g;
 
 /**
  * Extract math regions from raw model output, replacing them with placeholder


### PR DESCRIPTION
## Why

Two stacked bugs were breaking LaTeX in every Arc conversation:

**Bug A — Markdown ate the delimiters.** `MessageComponent` ran `marked.parse()` before `renderLatex()`. CommonMark backslash-escape rules treat `\(`, `\)`, `\[`, `\]` as escaped literals, so `\(n \ge 1\)` became `(n \ge 1)` before KaTeX ever saw it. Every Claude / GPT response containing math rendered as raw `\frac{…}`, `\boxed{…}`, `\mathbb E[…]` text.

**Bug B — Currency rendered as math.** The inline-`$` regex `/(?<!\$)\$(?!\$)…\$/g` cheerfully paired `\$100. I write a call with strike \$110` and rendered the prose between as italic serif math.

## What changed

- **Extract math regions to placeholder tokens *before* markdown parses, restore rendered KaTeX HTML after.** Placeholders are plain alphanumerics so marked passes them through unchanged.
- **Tighten the inline-`$` rule** (Pandoc-style): opening `$` must be followed by a non-digit non-whitespace char; closing `$` must be preceded by non-whitespace and not followed by a digit. Currency stays as text. `\$x + 1\$` still renders. Math intended as inline can always use `\(...\)` — which is what most models emit anyway.
- Same fix applied to `SharedMessageComponent.vue` so publicly-shared conversations render math too.
- `renderLatex()` kept as a deprecated export for any external callers; it now uses the new `extractMath`/`restoreMath` under the hood.

## Verification

Verified the new logic against 7 representative inputs in a real browser (single test summary below). Full workspace build passes.

| Input | Behavior | ✓ |
|---|---|---|
| `The expression \(n \ge 1\) holds.` | Extracted, KaTeX-rendered | ✓ |
| `\[\mathbb E[S_n] \approx \mu^{n-1}\]` | Extracted as display math | ✓ |
| `strike \$110, premium \$3` | Stays as text (currency) | ✓ |
| `Let \$x + 1\$ be the result.` | Inline math rendered | ✓ |
| `\$\$y = mx + b\$\$` | Display math rendered | ✓ |
| Mixed: `\$3 collected. By \(x = 2\)…` | Only the `\(…\)` matches | ✓ |
| `Compute \$x\$5 widgets.` | Adversarial — stays as text | ✓ |

## Risk

- Frontend-only, additive — no backend, schema, or websocket changes.
- Users who relied on a single `$x$` inline math with the loose rule will need to use `\(x\)` or `$$x$$` for the unusual case (e.g., math starting with a digit or surrounded by whitespace). The new rule still matches the overwhelmingly common forms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)