### PR TITLE
fix: support GIF attachments uniformly + consolidate image-file check

### DIFF
--- a/deprecated-claude-app/backend/src/services/anthropic.ts
+++ b/deprecated-claude-app/backend/src/services/anthropic.ts
@@ -3,6 +3,7 @@ import { Message, getActiveBranch, ModelSettings } from '@deprecated-claude/shar
 import { Database } from '../database/index.js';
 import { llmLogger } from '../utils/llmLogger.js';
 import sharp from 'sharp';
+import { isImageFile } from './attachment-utils.js';
 
 // Anthropic's image size limit is 5MB, we target 4MB to have margin
 const MAX_IMAGE_BYTES = 4 * 1024 * 1024;
@@ -674,10 +675,7 @@ export class AnthropicService {
   }
   
   private isImageAttachment(fileName: string): boolean {
-    // Note: GIF excluded - Anthropic API has issues with some GIF formats
-    const imageExtensions = ['jpg', 'jpeg', 'png', 'webp'];
-    const extension = fileName.split('.').pop()?.toLowerCase() || '';
-    return imageExtensions.includes(extension);
+    return isImageFile(fileName);
   }
   
   /**

--- a/deprecated-claude-app/backend/src/services/attachment-utils.ts
+++ b/deprecated-claude-app/backend/src/services/attachment-utils.ts
@@ -2,12 +2,12 @@
  * Shared utilities for handling message attachments across providers.
  *
  * Background: prior to this module, "is this filename an image?" was
- * reimplemented in five places (anthropic.ts, bedrock.ts, openrouter.ts,
- * inference.ts ×2) with subtle drift — most notably, four of them excluded
- * GIF with the comment "Anthropic API has issues with some GIF formats"
- * while OpenRouter silently allowed it. That meant the same Claude model
- * would accept a GIF when routed through OpenRouter but reject it when
- * routed through Bedrock or Anthropic-direct.
+ * reimplemented in six places (anthropic.ts, bedrock.ts, openrouter.ts,
+ * inference.ts ×3, context-strategies.ts) with subtle drift — most notably,
+ * five of them excluded GIF with the comment "Anthropic API has issues with
+ * some GIF formats" while OpenRouter silently allowed it. That meant the
+ * same Claude model would accept a GIF when routed through OpenRouter but
+ * reject it when routed through Bedrock or Anthropic-direct.
  *
  * The Anthropic Messages API documents image/jpeg, image/png, image/gif,
  * and image/webp as supported media types (animated GIFs are processed as

--- a/deprecated-claude-app/backend/src/services/attachment-utils.ts
+++ b/deprecated-claude-app/backend/src/services/attachment-utils.ts
@@ -1,0 +1,43 @@
+/**
+ * Shared utilities for handling message attachments across providers.
+ *
+ * Background: prior to this module, "is this filename an image?" was
+ * reimplemented in five places (anthropic.ts, bedrock.ts, openrouter.ts,
+ * inference.ts ×2) with subtle drift — most notably, four of them excluded
+ * GIF with the comment "Anthropic API has issues with some GIF formats"
+ * while OpenRouter silently allowed it. That meant the same Claude model
+ * would accept a GIF when routed through OpenRouter but reject it when
+ * routed through Bedrock or Anthropic-direct.
+ *
+ * The Anthropic Messages API documents image/jpeg, image/png, image/gif,
+ * and image/webp as supported media types (animated GIFs are processed as
+ * their first frame). The "GIF issues" comment appears to have been an
+ * over-cautious response to a specific past failure that ossified into
+ * blanket exclusion across copy-paste sites.
+ *
+ * This module is the single source of truth. Add new image formats here
+ * and they apply uniformly across all providers.
+ */
+
+/**
+ * Image file extensions accepted across all multi-modal providers.
+ *
+ * Kept conservative on purpose — providers that support additional formats
+ * (HEIC, BMP, TIFF, etc.) can still accept them by extending this list once
+ * we've confirmed each provider's behavior. The Anthropic Messages API,
+ * Bedrock Claude, OpenRouter, and Gemini all support this set.
+ */
+export const SUPPORTED_IMAGE_EXTENSIONS = ['jpg', 'jpeg', 'png', 'gif', 'webp'] as const;
+
+/**
+ * Return true if a filename looks like a supported image attachment.
+ *
+ * Pure filename check — does not inspect file content. Callers that also
+ * need to know "do we have data to send" should additionally check
+ * `attachment.content` (or equivalent) themselves.
+ */
+export function isImageFile(fileName: string | undefined | null): boolean {
+  if (!fileName) return false;
+  const ext = fileName.split('.').pop()?.toLowerCase() || '';
+  return (SUPPORTED_IMAGE_EXTENSIONS as readonly string[]).includes(ext);
+}

--- a/deprecated-claude-app/backend/src/services/bedrock.ts
+++ b/deprecated-claude-app/backend/src/services/bedrock.ts
@@ -3,6 +3,7 @@ import { Message, getActiveBranch, ModelSettings } from '@deprecated-claude/shar
 import { Database } from '../database/index.js';
 import { llmLogger } from '../utils/llmLogger.js';
 import sharp from 'sharp';
+import { isImageFile } from './attachment-utils.js';
 
 // Image size limit - Anthropic/Bedrock limit is 5MB, we target 4MB to have margin
 const MAX_IMAGE_BYTES = 4 * 1024 * 1024;
@@ -242,10 +243,7 @@ export class BedrockService {
   }
 
   private isImageAttachment(fileName: string): boolean {
-    // Note: GIF excluded - Anthropic API has issues with some GIF formats
-    const imageExtensions = ['jpg', 'jpeg', 'png', 'webp'];
-    const extension = fileName.split('.').pop()?.toLowerCase() || '';
-    return imageExtensions.includes(extension);
+    return isImageFile(fileName);
   }
   
   private isPdfAttachment(fileName: string): boolean {

--- a/deprecated-claude-app/backend/src/services/context-strategies.ts
+++ b/deprecated-claude-app/backend/src/services/context-strategies.ts
@@ -1,5 +1,6 @@
 import { Message, ContextManagement } from '@deprecated-claude/shared';
 import { Logger } from '../utils/logger.js';
+import { isImageFile } from './attachment-utils.js';
 
 export interface CacheMarker {
   messageId: string;
@@ -41,12 +42,7 @@ function estimateTokens(content: string): number {
 }
 
 function isImageAttachment(fileName?: string): boolean {
-  if (!fileName) return false;
-  // Note: GIF excluded - Anthropic API has issues with some GIF formats
-  // BMP and SVG also excluded - not widely supported by vision APIs
-  const imageExtensions = ['jpg', 'jpeg', 'png', 'webp'];
-  const ext = fileName.split('.').pop()?.toLowerCase() || '';
-  return imageExtensions.includes(ext);
+  return isImageFile(fileName);
 }
 
 function getMessageTokens(message: Message): number {

--- a/deprecated-claude-app/backend/src/services/inference.ts
+++ b/deprecated-claude-app/backend/src/services/inference.ts
@@ -9,6 +9,7 @@ import { ApiKeyManager } from './api-key-manager.js';
 import { ModelLoader } from '../config/model-loader.js';
 import { Logger } from '../utils/logger.js';
 import { ContextManager } from './context-manager.js';
+import { isImageFile } from './attachment-utils.js';
 
 // Internal format type that includes 'messages', 'completion', and 'pseudo-prefill' modes
 // - 'standard': Traditional alternating user/assistant (no participant names)
@@ -1061,14 +1062,10 @@ export class InferenceService {
       let messageIndex = 0;  // Track index for cache breakpoints
       let messageOrder = 1;  // For ordering output messages
       
-      // Helper to check if an attachment is an image
-      const isImageAttachment = (attachment: any): boolean => {
-        // Note: GIF excluded - Anthropic API has issues with some GIF formats
-        const imageExtensions = ['jpg', 'jpeg', 'png', 'webp'];
-        const fileExtension = attachment.fileName?.split('.').pop()?.toLowerCase() || '';
-        return imageExtensions.includes(fileExtension) && !!attachment.content;
-      };
-      
+      // Helper to check if an attachment is an image with data to send.
+      const isImageAttachment = (attachment: any): boolean =>
+        isImageFile(attachment.fileName) && !!attachment.content;
+
       // Helper to flush current conversation content as an assistant message
       const flushAssistantContent = () => {
         if (conversationContent.trim()) {
@@ -1271,12 +1268,9 @@ export class InferenceService {
         Logger.inference(`[PseudoPrefill] Injecting persona context (${Math.ceil(personaContext.length / 4)} est. tokens) into conversation log`);
       }
 
-      // Helper to check if an attachment is an image
-      const isImageAttachmentPP = (attachment: any): boolean => {
-        const imageExtensions = ['jpg', 'jpeg', 'png', 'webp'];
-        const fileExtension = attachment.fileName?.split('.').pop()?.toLowerCase() || '';
-        return imageExtensions.includes(fileExtension) && !!attachment.content;
-      };
+      // Helper to check if an attachment is an image with data to send.
+      const isImageAttachmentPP = (attachment: any): boolean =>
+        isImageFile(attachment.fileName) && !!attachment.content;
 
       // Track image messages that need separate user turns
       const imageTurns: Message[] = [];
@@ -1501,11 +1495,8 @@ export class InferenceService {
         // on the branch for providers (like Anthropic) that support multimodal inputs
         if (role === 'user' && activeBranch.attachments && activeBranch.attachments.length > 0) {
           for (const attachment of activeBranch.attachments) {
-            // Note: GIF excluded - Anthropic API has issues with some GIF formats
-            const imageExtensions = ['jpg', 'jpeg', 'png', 'webp'];
-            const fileExtension = attachment.fileName?.split('.').pop()?.toLowerCase() || '';
-            const isImage = imageExtensions.includes(fileExtension);
-            
+            const isImage = isImageFile(attachment.fileName);
+
             if (isImage) {
               formattedContent += `\n\n[Image attachment: ${attachment.fileName}]`;
             } else {

--- a/deprecated-claude-app/backend/src/services/openrouter.ts
+++ b/deprecated-claude-app/backend/src/services/openrouter.ts
@@ -4,6 +4,7 @@ import { getBlobStore } from '../database/blob-store.js';
 import { llmLogger } from '../utils/llmLogger.js';
 import { Logger } from '../utils/logger.js';
 import { logOpenRouterRequest, logOpenRouterResponse } from '../utils/openrouterLogger.js';
+import { isImageFile } from './attachment-utils.js';
 
 interface OpenRouterMessage {
   role: 'user' | 'assistant' | 'system';
@@ -724,7 +725,7 @@ export class OpenRouterService {
           
           for (const attachment of activeBranch.attachments) {
             const extension = attachment.fileName.split('.').pop()?.toLowerCase() || '';
-            const isImage = ['jpg', 'jpeg', 'png', 'gif', 'webp'].includes(extension);
+            const isImage = isImageFile(attachment.fileName);
             const isPdf = extension === 'pdf';
             
             if (isImage) {


### PR DESCRIPTION
## Why

Six separate files each had their own inline copy of "is this filename an image?", with subtly inconsistent behavior:

| Site | Includes GIF? |
|---|---|
| `anthropic.ts:676` | ❌ |
| `bedrock.ts:244` | ❌ |
| `inference.ts:1064` | ❌ |
| `inference.ts:1275` | ❌ |
| `inference.ts:1503` | ❌ |
| `context-strategies.ts:43` | ❌ |
| `openrouter.ts:727` | ✅ |

Four of the exclusions even shared the identical comment `// Note: GIF excluded - Anthropic API has issues with some GIF formats` — classic copy-paste.

**User impact:** the same Claude model accepts a GIF when routed through OpenRouter but silently strips it when routed through Anthropic-direct or Bedrock. The Anthropic Messages API documents `image/gif` as supported (animated GIFs are processed as their first frame), and Bedrock uses the same API contract.

## What changed

- New `backend/src/services/attachment-utils.ts`: a single `SUPPORTED_IMAGE_EXTENSIONS` constant and `isImageFile()` helper. Module header documents why this exists.
- All six call sites delegate to the helper. Class-private `isImageAttachment` wrappers in anthropic.ts/bedrock.ts kept as one-line shims so internal call sites don't need rewriting.
- GIF added to the supported set across the board.

## Risk

- Backend-only.
- Behavior change: GIF attachments will now be sent as `image/gif` to Anthropic & Bedrock (previously stripped and sent as text). The provider APIs document GIF support, so this should "just work." If a specific GIF causes an API-level error, that error will surface to the user — better than silent failure.
- No new dependencies, no schema changes.

## Next steps in this area

Per [REVIEW_FINDINGS.md] Q2-2: this is the first step. Subsequent PRs can pull more provider helpers (`getMediaType` exists in 4 files with drift, `resizeImageIfNeeded` exists in 2 files byte-identical) into the same module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)