### PR TITLE
sec: enforce JWT_SECRET min length + reject placeholder values

### DIFF
--- a/deprecated-claude-app/backend/env.example
+++ b/deprecated-claude-app/backend/env.example
@@ -3,8 +3,11 @@ PORT=3010
 FRONTEND_URL=http://localhost:5173
 
 # Authentication (REQUIRED - server will not start without this)
+# Must be at least 32 characters; the placeholder below is rejected by the
+# server. Generate a real secret with:  openssl rand -hex 32
 JWT_SECRET=your-secret-key-change-in-production
-# Optional: dedicated key for API key encryption (falls back to JWT_SECRET)
+# Optional: dedicated key for API key encryption (falls back to JWT_SECRET).
+# Same generation method:  openssl rand -hex 32
 # ENCRYPTION_KEY=
 
 # Configuration File Path (optional)

--- a/deprecated-claude-app/backend/src/middleware/auth.ts
+++ b/deprecated-claude-app/backend/src/middleware/auth.ts
@@ -7,14 +7,51 @@ export interface AuthRequest extends Request {
   params: any;
 }
 
-// BREAKING CHANGE: JWT_SECRET is now required. The server will refuse to start
-// without it. Previously it fell back to a hardcoded default that was visible in
-// source code, allowing anyone to forge auth tokens. Ensure JWT_SECRET is set in
-// all deployment environments (staging, production) before deploying this change.
+// JWT_SECRET is required AND must be sufficiently long. Tokens are signed with
+// HS256; a short secret can be brute-forced offline from any issued token,
+// after which an attacker can forge auth tokens for any user. RFC 7518 requires
+// at least 256 bits of entropy for HS256 keys — we enforce 32 characters as a
+// floor (ASCII chars are ~7 bits each, so 32 chars ≈ 224 bits worst case; the
+// recommendation in error text is 64 hex chars = 256 bits exactly).
+//
+// History: previously the server fell back to a hardcoded default visible in
+// source code. That was fixed; this commit additionally rejects short or
+// placeholder secrets at startup so a weak rotation can't slip in unnoticed.
+const MIN_SECRET_LENGTH = 32;
+
+// Well-known placeholder values that have appeared in env.example or similar.
+// These pass the length check but are obviously not real secrets.
+const KNOWN_PLACEHOLDER_SECRETS: ReadonlySet<string> = new Set([
+  'your-secret-key-change-in-production',
+  'local-dev-secret-change-in-production',
+  'changeme',
+  'change-me',
+  'CHANGE_ME',
+  'your-jwt-secret-here',
+]);
+
+const SECRET_GENERATION_HINT =
+  'Generate a strong secret with:\n    openssl rand -hex 32';
+
 function getJwtSecret(): string {
   const secret = process.env.JWT_SECRET;
   if (!secret) {
-    throw new Error('JWT_SECRET environment variable is required. Set it to a strong random secret (32+ characters).');
+    throw new Error(
+      `JWT_SECRET environment variable is required.\n${SECRET_GENERATION_HINT}`,
+    );
+  }
+  if (secret.length < MIN_SECRET_LENGTH) {
+    throw new Error(
+      `JWT_SECRET is too short (${secret.length} chars; minimum ${MIN_SECRET_LENGTH}). ` +
+      `A short secret can be brute-forced offline from an issued token, ` +
+      `letting an attacker forge auth tokens for any user.\n${SECRET_GENERATION_HINT}`,
+    );
+  }
+  if (KNOWN_PLACEHOLDER_SECRETS.has(secret)) {
+    throw new Error(
+      `JWT_SECRET is set to a well-known placeholder value. ` +
+      `This is not a real secret.\n${SECRET_GENERATION_HINT}`,
+    );
   }
   return secret;
 }


### PR DESCRIPTION
## Why

`middleware/auth.ts` previously accepted **any** non-empty `JWT_SECRET`, including single-character secrets and the well-known placeholder values shipped in `env.example`. The text-only \"32+ chars\" hint in the existing error message was not actually enforced.

A short HS256 secret can be brute-forced offline from any single issued token; the attacker can then forge auth tokens for arbitrary users. Combined with the historical credential leak (commit `d5632bd`, rotated since), nothing in the codebase caught a possible weak replacement.

## What changed

- Refuse to start if `JWT_SECRET` is < **32 characters** (RFC 7518 minimum for HS256). 32 ASCII chars ≈ 224 bits worst-case entropy; 64 hex chars (recommended) gives 256 bits.
- Refuse to start if `JWT_SECRET` matches a well-known placeholder string (`your-secret-key-change-in-production`, `CHANGE_ME`, etc.) — these pass the length check but obviously aren't real secrets.
- Error messages now include the exact command to generate a real secret: \`openssl rand -hex 32\`.
- Updated `env.example` to document the requirement.

## Operational note

If a deployment is currently running with a short or placeholder `JWT_SECRET`, the server will **refuse to start** after this lands. That's the intended behavior — the operator should rotate to a real secret (and update env) before deploying. Production should already be on a real rotated secret post-leak; staging and any local dev may need updates.

## Verification

Seven self-tests covering:

| Input | Behavior |
|---|---|
| unset | REJECTED |
| `'x'` | REJECTED (too short) |
| 31 `'a'`s | REJECTED (just below threshold) |
| 32 `'a'`s | accepted (at threshold) |
| `'your-secret-key-change-in-production'` (35 chars) | REJECTED (placeholder) |
| `'CHANGE_ME'` | REJECTED (short placeholder) |
| 40 random chars | accepted |

🤖 Generated with [Claude Code](https://claude.com/claude-code)