### PR TITLE
sec: harden capability tokens (entropy + rate limiting)

### DIFF
--- a/deprecated-claude-app/backend/package.json
+++ b/deprecated-claude-app/backend/package.json
@@ -22,6 +22,7 @@
     "cors": "^2.8.5",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
+    "express-rate-limit": "8.5.1",
     "jsonwebtoken": "^9.0.2",
     "multer": "^2.0.2",
     "resend": "^6.6.0",

--- a/deprecated-claude-app/backend/src/database/collaboration.ts
+++ b/deprecated-claude-app/backend/src/database/collaboration.ts
@@ -315,8 +315,10 @@ export class CollaborationStore {
   private generateInviteToken(): string {
     let token: string;
     do {
-      // Generate 12 character alphanumeric token (more secure than share tokens)
-      token = crypto.randomBytes(6).toString('hex');
+      // 16 bytes = 32 hex chars = 128 bits. Treat as a capability token —
+      // collaboration invites grant write access to a private conversation
+      // for whoever holds the link. Previously 12 hex chars (48 bits).
+      token = crypto.randomBytes(16).toString('hex');
     } while (this.invitesByToken.has(token));
     return token;
   }

--- a/deprecated-claude-app/backend/src/database/shares.ts
+++ b/deprecated-claude-app/backend/src/database/shares.ts
@@ -73,8 +73,11 @@ export class SharesStore {
   private generateToken(): string {
     let token: string;
     do {
-      // Generate 10 character alphanumeric token
-      token = crypto.randomBytes(5).toString('hex');
+      // 16 bytes = 32 hex chars = 128 bits. Treat as a capability token —
+      // anyone with the share URL can read private conversation content.
+      // Previously 10 hex chars (40 bits), brute-forceable for targeted
+      // attacks against specific known share contexts.
+      token = crypto.randomBytes(16).toString('hex');
     } while (this.sharesByToken.has(token));
     return token;
   }

--- a/deprecated-claude-app/backend/src/index.ts
+++ b/deprecated-claude-app/backend/src/index.ts
@@ -41,6 +41,13 @@ dotenv.config();
 
 const app = express();
 
+// Honor X-Forwarded-For from the local nginx so `req.ip` is the real
+// client IP. Required for per-IP rate limiting to be meaningful — without
+// this, every request looks like it comes from the loopback nginx.
+// `'loopback'` is the safe choice: trust only the nginx running on the
+// same host, never accept the header from a public-internet client.
+app.set('trust proxy', 'loopback');
+
 // Initialize database
 const db = new Database();
 

--- a/deprecated-claude-app/backend/src/middleware/rate-limit.ts
+++ b/deprecated-claude-app/backend/src/middleware/rate-limit.ts
@@ -1,0 +1,76 @@
+/**
+ * Rate-limiting middleware for unauthenticated and abuse-prone endpoints.
+ *
+ * Two limiters with different thresholds:
+ *
+ *   - `authLimiter`         : login, register, forgot-password, etc.
+ *                              Tight — these are brute-force targets and
+ *                              email-send-cost surfaces.
+ *
+ *   - `tokenLookupLimiter`  : public lookups by capability token (invite
+ *                              `/check`, share-by-token view, collab invite
+ *                              preview). More permissive than auth since
+ *                              legitimate users may load these multiple
+ *                              times per session.
+ *
+ * Both key off `req.ip`. For this to be meaningful behind nginx, the
+ * backend sets `app.set('trust proxy', 'loopback')` so X-Forwarded-For from
+ * the local nginx is honored. Without that, every request would key to the
+ * nginx loopback address and the limit would be useless.
+ *
+ * Defense-in-depth: the primary protection against capability-token brute
+ * force is high token entropy (128 bits, see invites.ts / shares.ts /
+ * collaboration.ts). Rate limiting blocks the *single-IP* enumeration
+ * vector and slows credential-stuffing on login — botnets routing through
+ * many IPs are not stopped by per-IP limits, but with full-entropy tokens
+ * there is nothing reachable to find by enumeration anyway.
+ *
+ * Thresholds can be overridden via env vars for ops flexibility (e.g. for
+ * load-testing or staging tighter/looser policies):
+ *
+ *   AUTH_RATE_LIMIT_MAX           (default 10)
+ *   AUTH_RATE_LIMIT_WINDOW_MIN    (default 5)
+ *   TOKEN_LOOKUP_RATE_LIMIT_MAX           (default 60)
+ *   TOKEN_LOOKUP_RATE_LIMIT_WINDOW_MIN    (default 5)
+ */
+import rateLimit from 'express-rate-limit';
+
+const minutes = (n: number) => n * 60 * 1000;
+
+function readNumberEnv(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const n = Number(raw);
+  return Number.isFinite(n) && n > 0 ? n : fallback;
+}
+
+const AUTH_MAX = readNumberEnv('AUTH_RATE_LIMIT_MAX', 10);
+const AUTH_WINDOW_MIN = readNumberEnv('AUTH_RATE_LIMIT_WINDOW_MIN', 5);
+const TOKEN_LOOKUP_MAX = readNumberEnv('TOKEN_LOOKUP_RATE_LIMIT_MAX', 60);
+const TOKEN_LOOKUP_WINDOW_MIN = readNumberEnv('TOKEN_LOOKUP_RATE_LIMIT_WINDOW_MIN', 5);
+
+/**
+ * Tighter limiter for auth-credential endpoints (login, register, password
+ * reset, email verification). At default settings: 10 requests per 5 minutes
+ * per IP. Returns 429 with a `Retry-After` header when exceeded.
+ */
+export const authLimiter = rateLimit({
+  windowMs: minutes(AUTH_WINDOW_MIN),
+  max: AUTH_MAX,
+  standardHeaders: true,   // emit RateLimit-* headers (RFC draft)
+  legacyHeaders: false,    // drop the older X-RateLimit-* variants
+  message: { error: 'Too many requests. Please try again later.' },
+});
+
+/**
+ * Permissive limiter for public capability-token lookups (invite check,
+ * share-by-token view, collab invite preview). At default settings: 60
+ * requests per 5 minutes per IP.
+ */
+export const tokenLookupLimiter = rateLimit({
+  windowMs: minutes(TOKEN_LOOKUP_WINDOW_MIN),
+  max: TOKEN_LOOKUP_MAX,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { error: 'Too many requests. Please try again later.' },
+});

--- a/deprecated-claude-app/backend/src/routes/auth.ts
+++ b/deprecated-claude-app/backend/src/routes/auth.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { v4 as uuidv4 } from 'uuid';
 import { Database } from '../database/index.js';
 import { generateToken, authenticateToken, AuthRequest } from '../middleware/auth.js';
+import { authLimiter, tokenLookupLimiter } from '../middleware/rate-limit.js';
 import { ConfigLoader } from '../config/loader.js';
 import { ModelLoader } from '../config/model-loader.js';
 import { sendVerificationEmail, sendPasswordResetEmail } from '../services/email.js';
@@ -65,7 +66,7 @@ export function authRouter(db: Database): Router {
   });
 
   // Register - now requires email verification
-  router.post('/register', async (req, res) => {
+  router.post('/register', authLimiter, async (req, res) => {
     try {
       const data = RegisterSchema.parse(req.body);
       
@@ -178,7 +179,7 @@ export function authRouter(db: Database): Router {
   });
   
   // Verify email
-  router.post('/verify-email', async (req, res) => {
+  router.post('/verify-email', authLimiter, async (req, res) => {
     try {
       const { token } = req.body;
       
@@ -212,7 +213,7 @@ export function authRouter(db: Database): Router {
   });
   
   // Resend verification email
-  router.post('/resend-verification', async (req, res) => {
+  router.post('/resend-verification', authLimiter, async (req, res) => {
     try {
       const data = ResendVerificationSchema.parse(req.body);
       
@@ -249,7 +250,7 @@ export function authRouter(db: Database): Router {
   });
 
   // Login
-  router.post('/login', async (req, res) => {
+  router.post('/login', authLimiter, async (req, res) => {
     try {
       const data = LoginSchema.parse(req.body);
       
@@ -301,7 +302,7 @@ export function authRouter(db: Database): Router {
   });
   
   // Forgot password - request reset email
-  router.post('/forgot-password', async (req, res) => {
+  router.post('/forgot-password', authLimiter, async (req, res) => {
     try {
       const data = ForgotPasswordSchema.parse(req.body);
       
@@ -324,7 +325,7 @@ export function authRouter(db: Database): Router {
   });
   
   // Reset password with token
-  router.post('/reset-password', async (req, res) => {
+  router.post('/reset-password', authLimiter, async (req, res) => {
     try {
       const data = ResetPasswordSchema.parse(req.body);
       
@@ -345,7 +346,7 @@ export function authRouter(db: Database): Router {
   });
   
   // Validate reset token (to check before showing reset form)
-  router.get('/reset-password/:token', async (req, res) => {
+  router.get('/reset-password/:token', tokenLookupLimiter, async (req, res) => {
     try {
       const { token } = req.params;
       const tokenData = db.getPasswordResetTokenData(token);

--- a/deprecated-claude-app/backend/src/routes/collaboration.ts
+++ b/deprecated-claude-app/backend/src/routes/collaboration.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import { Database } from '../database/index.js';
 import { authenticateToken } from '../middleware/auth.js';
+import { tokenLookupLimiter } from '../middleware/rate-limit.js';
 import { SharePermission } from '@deprecated-claude/shared';
 
 export function collaborationRouter(db: Database): Router {
@@ -11,10 +12,11 @@ export function collaborationRouter(db: Database): Router {
   // ==========================================
 
   /**
-   * Get invite details by token (public - for redemption page)
+   * Get invite details by token (public - for redemption page).
+   * Rate-limited per-IP since the token is the only capability check.
    * GET /api/collaboration/invites/token/:token
    */
-  router.get('/invites/token/:token', async (req, res) => {
+  router.get('/invites/token/:token', tokenLookupLimiter, async (req, res) => {
     try {
       const { token } = req.params;
       

--- a/deprecated-claude-app/backend/src/routes/invites.ts
+++ b/deprecated-claude-app/backend/src/routes/invites.ts
@@ -1,12 +1,17 @@
 import { Router } from 'express';
 import { Database } from '../database/index.js';
 import { authenticateToken, AuthRequest } from '../middleware/auth.js';
+import { tokenLookupLimiter } from '../middleware/rate-limit.js';
 import { z } from 'zod';
 import crypto from 'crypto';
 
 function generateInviteCode(): string {
-  // Generate a random 8-character alphanumeric code
-  return crypto.randomBytes(4).toString('hex');
+  // 16 bytes = 32 hex chars = 128 bits of entropy. Treat as a capability
+  // token — each invite is literally credit. Previously 8 hex chars (32 bits),
+  // which is brute-forceable from a public oracle in hours. Older codes still
+  // validate (lookup is by string match), but new codes from now on are full
+  // entropy.
+  return crypto.randomBytes(16).toString('hex');
 }
 
 export function createInvitesRouter(db: Database): Router {
@@ -88,8 +93,11 @@ export function createInvitesRouter(db: Database): Router {
     }
   });
 
-  // Check if an invite code is valid (public endpoint for UI validation)
-  router.get('/:code/check', async (req, res) => {
+  // Check if an invite code is valid (public endpoint for UI validation).
+  // Rate-limited because this is a public oracle: combined with the (now-
+  // fixed-but-historically-low) entropy of invite codes, an unthrottled
+  // version was the brute-force-credits vector.
+  router.get('/:code/check', tokenLookupLimiter, async (req, res) => {
     try {
       const { code } = req.params;
       const validation = db.validateInvite(code);

--- a/deprecated-claude-app/backend/src/routes/shares.ts
+++ b/deprecated-claude-app/backend/src/routes/shares.ts
@@ -2,6 +2,7 @@ import { Router, Request, Response } from 'express';
 import { z } from 'zod';
 import { Database } from '../database/index.js';
 import { authenticateToken } from '../middleware/auth.js';
+import { tokenLookupLimiter } from '../middleware/rate-limit.js';
 import { ModelLoader } from '../config/model-loader.js';
 
 const router = Router();
@@ -101,8 +102,9 @@ export function createShareRouter(db: Database): Router {
     }
   });
   
-  // Get shared conversation data (no auth required - public endpoint)
-  router.get('/:token', async (req: Request, res: Response) => {
+  // Get shared conversation data (no auth required - public endpoint).
+  // Rate-limited per-IP because the token is the only capability check.
+  router.get('/:token', tokenLookupLimiter, async (req: Request, res: Response) => {
     try {
       const { token } = req.params;
       

--- a/deprecated-claude-app/package-lock.json
+++ b/deprecated-claude-app/package-lock.json
@@ -36,6 +36,7 @@
         "cors": "^2.8.5",
         "dotenv": "^16.3.1",
         "express": "^4.18.2",
+        "express-rate-limit": "8.5.1",
         "jsonwebtoken": "^9.0.2",
         "multer": "^2.0.2",
         "resend": "^6.6.0",
@@ -5098,6 +5099,24 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.1.tgz",
+      "integrity": "sha512-5O6KYmyJEpuPJV5hNTXKbAHWRqrzyu+OI3vUnSd2kXFubIVpG7ezpgxQy76Zo5GQZtrQBg86hF+CM/NX+cioiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/fast-sha256": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
@@ -5547,6 +5566,15 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/ipaddr.js": {


### PR DESCRIPTION
## Why

The low-effort \"vibe-hacking\" threat — bot armies sweeping public endpoints for cheap wins — finds three real targets in the current code:

| Token | Old entropy | Endpoint exposed publicly | Reward |
|---|---|---|---|
| Invite code | 32 bits (`randomBytes(4)`) | `GET /api/invites/:code/check` — returns `{valid, amount, currency}` | Each unclaimed invite is literally credit. Brute-forceable single-IP in hours. |
| Share token | 40 bits (`randomBytes(5)`) | `GET /api/shares/:token` — full private conversation content | Brute-forceable for targeted attacks. |
| Collab invite | 48 bits (`randomBytes(6)`) | `GET /api/collaboration/invites/token/:token` + redemption | Grants write access to a private conversation. |

None of these were rate-limited; no `trust proxy` was set, so even if rate limiting had been added it would have keyed every request to the local nginx loopback.

## What changed

**1. Capability-token entropy → 128 bits everywhere.** All three token generators now use `crypto.randomBytes(16).toString('hex')`. Existing short tokens still validate (lookup is by string match) so live invites and shares keep working; operators may choose to mass-rotate high-value old invites separately.

**2. New `backend/src/middleware/rate-limit.ts`** exposes two limiters:

- `authLimiter` — default **10 req / 5 min / IP**, applied to: `register`, `login`, `verify-email`, `resend-verification`, `forgot-password`, `reset-password`.
- `tokenLookupLimiter` — default **60 req / 5 min / IP**, applied to: `reset-password/:token`, `invites/:code/check`, `shares/:token`, `collaboration/invites/token/:token`.

Env-overridable: `AUTH_RATE_LIMIT_MAX`, `AUTH_RATE_LIMIT_WINDOW_MIN`, `TOKEN_LOOKUP_RATE_LIMIT_MAX`, `TOKEN_LOOKUP_RATE_LIMIT_WINDOW_MIN`.

**3. `app.set('trust proxy', 'loopback')`** in `index.ts` so `req.ip` resolves to the real client IP through nginx. `'loopback'` is the conservative scope — only honors `X-Forwarded-For` when the immediate hop is 127.0.0.1; never accepts the header from a public-internet client.

**4. New dependency:** `express-rate-limit` ^8.5.1. Well-maintained, memory store by default, no Redis required (matches the single-process Node architecture).

## Threat model note

Botnets routing through many IPs bypass per-IP rate limits — but with 128-bit capability tokens, there is no longer anything reachable to find by enumeration. The rate limit is defense-in-depth that catches single-IP scanners (the actual vibe-hacking pattern) and also slows credential stuffing on `/login`.

## Verification

- Entropy: confirmed 32 hex chars / 128 bits for all three token types.
- Rate limit: end-to-end smoke test with a tiny Express app (`AUTH_RATE_LIMIT_MAX=3`) — first 3 requests returned 200, 4th and 5th returned 429 with standard `RateLimit-*` headers.
- Workspace `npm run build` clean.

## Operational note

If the production nginx is doing anything other than passing through `X-Forwarded-For` from the public client unchanged, the `'loopback'` trust setting may need tightening or relaxing. Default behavior of standard `nginx` configs (proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;) is correct for this setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)