### PR TITLE
fix: Greptile-flagged edge cases in JWT validation + rate-limit env parsing

### DIFF
--- a/deprecated-claude-app/backend/src/middleware/auth.ts
+++ b/deprecated-claude-app/backend/src/middleware/auth.ts
@@ -21,12 +21,13 @@ const MIN_SECRET_LENGTH = 32;
 
 // Well-known placeholder values that have appeared in env.example or similar.
 // These pass the length check but are obviously not real secrets.
+// Stored lowercase; comparison is case-insensitive (Greptile review of #91).
 const KNOWN_PLACEHOLDER_SECRETS: ReadonlySet<string> = new Set([
   'your-secret-key-change-in-production',
   'local-dev-secret-change-in-production',
   'changeme',
   'change-me',
-  'CHANGE_ME',
+  'change_me',
   'your-jwt-secret-here',
 ]);
 
@@ -34,25 +35,40 @@ const SECRET_GENERATION_HINT =
   'Generate a strong secret with:\n    openssl rand -hex 32';
 
 function getJwtSecret(): string {
-  const secret = process.env.JWT_SECRET;
-  if (!secret) {
+  const raw = process.env.JWT_SECRET;
+  if (!raw) {
     throw new Error(
       `JWT_SECRET environment variable is required.\n${SECRET_GENERATION_HINT}`,
     );
   }
+
+  // Trim whitespace before any check (Greptile review of #91): a value like
+  // `"               x               "` from a misconfigured env file or
+  // copy-paste mishap is 33 characters long and would pass the length guard
+  // while having ~1 character of effective entropy. We trim once and use the
+  // trimmed value for both validation and signing.
+  const secret = raw.trim();
+
   if (secret.length < MIN_SECRET_LENGTH) {
     throw new Error(
-      `JWT_SECRET is too short (${secret.length} chars; minimum ${MIN_SECRET_LENGTH}). ` +
-      `A short secret can be brute-forced offline from an issued token, ` +
-      `letting an attacker forge auth tokens for any user.\n${SECRET_GENERATION_HINT}`,
+      `JWT_SECRET is too short (${secret.length} chars after trimming whitespace; ` +
+      `minimum ${MIN_SECRET_LENGTH}). A short secret can be brute-forced offline ` +
+      `from an issued token, letting an attacker forge auth tokens for any user.\n` +
+      `${SECRET_GENERATION_HINT}`,
     );
   }
-  if (KNOWN_PLACEHOLDER_SECRETS.has(secret)) {
+
+  // Case-insensitive placeholder check (Greptile review of #91): a developer
+  // copying the well-known value with any casing variation (e.g.
+  // `Your-Secret-Key-Change-In-Production`) would otherwise bypass the
+  // blocklist while still being a meaningless secret.
+  if (KNOWN_PLACEHOLDER_SECRETS.has(secret.toLowerCase())) {
     throw new Error(
       `JWT_SECRET is set to a well-known placeholder value. ` +
       `This is not a real secret.\n${SECRET_GENERATION_HINT}`,
     );
   }
+
   return secret;
 }
 const JWT_SECRET: string = getJwtSecret();

--- a/deprecated-claude-app/backend/src/middleware/rate-limit.ts
+++ b/deprecated-claude-app/backend/src/middleware/rate-limit.ts
@@ -41,7 +41,18 @@ function readNumberEnv(name: string, fallback: number): number {
   const raw = process.env[name];
   if (!raw) return fallback;
   const n = Number(raw);
-  return Number.isFinite(n) && n > 0 ? n : fallback;
+  // Greptile review of #92: a fractional value like `0.5` previously slipped
+  // through (`Number.isFinite(0.5) && 0.5 > 0` is true) and got passed
+  // straight to express-rate-limit. The very first request then triggered
+  // 429 because `1 >= 0.5`. Limiter values must be positive integers.
+  if (!Number.isInteger(n) || n < 1) {
+    console.warn(
+      `[rate-limit] Ignoring invalid ${name}="${raw}" — must be a positive ` +
+      `integer. Using default ${fallback}.`,
+    );
+    return fallback;
+  }
+  return n;
 }
 
 const AUTH_MAX = readNumberEnv('AUTH_RATE_LIMIT_MAX', 10);


### PR DESCRIPTION
## Why

Three small post-merge fixups for items Greptile flagged on PRs #91 and #92. None are urgent (the original PRs already closed the headline vulnerabilities) but each is a real edge case worth fixing.

## #91 (JWT validation) — two issues

**(a) Trim whitespace before all checks.** A value like `\"               x               \"` (~33 chars of mostly whitespace) was previously passing the length guard while having effectively 1 character of entropy. Now trimmed once and the trimmed value is what gets validated AND signed with.

**(b) Case-insensitive placeholder check.** A developer copying the well-known placeholder with any casing (e.g. `Your-Secret-Key-Change-In-Production`) would otherwise bypass the blocklist. Now compares `secret.toLowerCase()` against an all-lowercase set.

## #92 (rate-limit env parsing) — one issue

**(c) Reject non-integer / sub-1 max values.** `AUTH_RATE_LIMIT_MAX=0.5` previously slipped through `Number.isFinite() && > 0`, passed to express-rate-limit, and made the very first request 429 (`1 >= 0.5`). Now requires positive integer; falls back to default with a warning.

## Verified

14 self-tests pass — all 7 JWT cases and all 7 rate-limit cases. Build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)