### PR TITLE
fix: remove 20-custom-model cap + enable Anthropic extended-cache TTL beta

### DIFF
--- a/deprecated-claude-app/backend/src/database/index.ts
+++ b/deprecated-claude-app/backend/src/database/index.ts
@@ -4979,12 +4979,15 @@ export class Database {
   // User Model methods
   async createUserModel(userId: string, modelData: import('@deprecated-claude/shared').CreateUserModel): Promise<UserDefinedModel> {
     await this.loadUser(userId); // Ensure user data is loaded
-    
-    // Limit number of custom models per user
-    const existingModels = await this.getUserModels(userId);
-    if (existingModels.length >= 20) {
-      throw new Error('Maximum number of custom models (20) reached');
-    }
+
+    // No per-user cap on custom-model count: a major appeal of Arc is the
+    // ability to add arbitrary OpenRouter models, and a cap of 20 was
+    // visibly insufficient. The earlier ensureUser load + rate limiting on
+    // the auth-protected POST endpoint provide the relevant DoS surface
+    // protection. If a per-user storage budget becomes desirable later,
+    // implement it as an explicit per-tier policy rather than a hardcoded
+    // ceiling here.
+    await this.getUserModels(userId);
 
     // Resolve settings with validation
     let resolvedSettings = modelData.settings;

--- a/deprecated-claude-app/backend/src/services/anthropic.ts
+++ b/deprecated-claude-app/backend/src/services/anthropic.ts
@@ -21,7 +21,17 @@ export class AnthropicService {
     }
     
     this.client = new Anthropic({
-      apiKey: resolvedKey || 'missing-api-key'
+      apiKey: resolvedKey || 'missing-api-key',
+      // Opt in to the extended-cache-TTL beta so the `cache_control: { ttl: '1h' }`
+      // markers we emit on system prompts and message-history breakpoints actually
+      // mean 1 hour. Without this header the API silently falls back to the
+      // default 5-minute ephemeral TTL — the request still succeeds and caching
+      // still works, just for a shorter window than the code intends. That's a
+      // significant cost-savings regression for long-running conversations
+      // (which were the whole point of the 1h TTL choice).
+      defaultHeaders: {
+        'anthropic-beta': 'extended-cache-ttl-2025-04-11',
+      },
     });
   }
 


### PR DESCRIPTION
## Two small backend correctness fixes

### Custom-models cap removal

`Database.createUserModel` previously refused to create more than 20 custom user models per account. A core appeal of Arc is being able to add arbitrary OpenRouter models (the catalog is hundreds); 20 is visibly insufficient.

The auth + rate-limit middleware on the create-custom-model endpoint provides the relevant DoS-surface protection; a hardcoded ceiling adds nothing on top. If per-user storage limits become desirable, they should be a tier policy not an inline constant.

### Anthropic extended-cache TTL beta header

The codebase emits `cache_control: { type: 'ephemeral', ttl: '1h' }` on system prompts and history breakpoints, intending 1-hour caching. But without the `extended-cache-ttl-2025-04-11` beta header the API silently falls back to the default 5-minute TTL — caching still works, just for 1/12 the intended window.

Fix: add the beta header to the Anthropic client init. Long conversations stop paying ~12× extra cache-creation tokens.

(Note: an earlier review-pass framed this as "the format `'1h'` is wrong, should be a number." That was incorrect — Anthropic does accept string TTLs, gated behind the beta header. The header was the missing piece.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)