### PR TITLE
Mobile fixes: dynamic viewport height + secure-context UUID fallback

### DIFF
--- a/deprecated-claude-app/frontend/src/components/AvatarPacksTab.vue
+++ b/deprecated-claude-app/frontend/src/components/AvatarPacksTab.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-card-text style="max-height: calc(100vh - 220px); overflow-y: auto; padding: 24px 24px 32px;">
+  <v-card-text style="max-height: calc(100dvh - 220px); overflow-y: auto; padding: 24px 24px 32px;">
     <div class="text-body-2 mb-4">
       Avatar packs provide visual identities for AI models. Select an active pack to use its avatars in conversations.
     </div>

--- a/deprecated-claude-app/frontend/src/components/CustomModelsTab.vue
+++ b/deprecated-claude-app/frontend/src/components/CustomModelsTab.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-card-text style="max-height: calc(100vh - 220px); overflow-y: auto; padding: 24px 24px 32px;">
+  <v-card-text style="max-height: calc(100dvh - 220px); overflow-y: auto; padding: 24px 24px 32px;">
     <div class="text-body-2 mb-4">
       Add your own models from OpenRouter or connect to custom OpenAI-compatible endpoints (Ollama, LM Studio, vLLM, etc.).
       Your custom models will appear alongside system models in the model selector.

--- a/deprecated-claude-app/frontend/src/components/SettingsDialog.vue
+++ b/deprecated-claude-app/frontend/src/components/SettingsDialog.vue
@@ -244,7 +244,7 @@
         
         <!-- About Tab -->
         <v-window-item value="about">
-          <v-card-text style="max-height: calc(100vh - 120px); overflow-y: auto; padding: 24px 24px 32px;">
+          <v-card-text style="max-height: calc(100dvh - 120px); overflow-y: auto; padding: 24px 24px 32px;">
             <h4 class="text-h6 mb-2">The Arc Chat</h4>
             <p class="text-body-2 mb-4">
               Version 1.0.0

--- a/deprecated-claude-app/frontend/src/store/index.ts
+++ b/deprecated-claude-app/frontend/src/store/index.ts
@@ -3,6 +3,7 @@ import type { User, Conversation, Message, Model, OpenRouterModel, UserDefinedMo
 import { getValidatedModelDefaults } from '@deprecated-claude/shared';
 import { api } from '../services/api';
 import { WebSocketService } from '../services/websocket';
+import { createClientUuid } from '../utils/uuid';
 
 // Model availability info - which providers user can use
 interface ModelAvailability {
@@ -675,7 +676,7 @@ export function createStore(): {
       const messageData = {
         type: 'chat' as const,
         conversationId: state.currentConversation.id,
-        messageId: crypto.randomUUID(),
+        messageId: createClientUuid(),
         content,
         parentBranchId,
         participantId,
@@ -723,7 +724,7 @@ export function createStore(): {
       state.wsService.sendMessage({
         type: 'continue',
         conversationId: state.currentConversation.id,
-        messageId: crypto.randomUUID(),
+        messageId: createClientUuid(),
         parentBranchId,
         responderId,
         samplingBranches: samplingBranches && samplingBranches > 1 ? samplingBranches : undefined

--- a/deprecated-claude-app/frontend/src/utils/uuid.ts
+++ b/deprecated-claude-app/frontend/src/utils/uuid.ts
@@ -1,0 +1,41 @@
+/**
+ * Generate a v4 UUID for client-side message IDs.
+ *
+ * Wraps `crypto.randomUUID()` with fallbacks because that API is gated to
+ * "secure contexts" — origins served over HTTPS, plus `localhost`/`127.0.0.1`
+ * as special cases. Plain HTTP on a LAN hostname or IP (e.g. accessing a dev
+ * server over Tailscale at `http://hostname:5173`) is NOT a secure context,
+ * so `crypto.randomUUID` is undefined there and calling it throws synchronously.
+ *
+ * Fallbacks, in order:
+ *   1. `crypto.randomUUID()` when available (modern HTTPS / localhost).
+ *   2. `crypto.getRandomValues()` with manual RFC 4122 v4 bit-packing
+ *      (available in all browsers, including non-secure contexts).
+ *   3. `Math.random()` as a last resort for very locked-down environments.
+ */
+export function createClientUuid(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+
+  const bytes = new Uint8Array(16);
+  if (typeof crypto !== 'undefined' && typeof crypto.getRandomValues === 'function') {
+    crypto.getRandomValues(bytes);
+  } else {
+    for (let i = 0; i < bytes.length; i++) {
+      bytes[i] = Math.floor(Math.random() * 256);
+    }
+  }
+
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+
+  const hex = Array.from(bytes, byte => byte.toString(16).padStart(2, '0')).join('');
+  return [
+    hex.slice(0, 8),
+    hex.slice(8, 12),
+    hex.slice(12, 16),
+    hex.slice(16, 20),
+    hex.slice(20)
+  ].join('-');
+}

--- a/deprecated-claude-app/frontend/src/views/AboutView.vue
+++ b/deprecated-claude-app/frontend/src/views/AboutView.vue
@@ -331,7 +331,7 @@ const { config: siteConfig, features, links } = useSiteConfig();
 @import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;500&display=swap');
 
 .arc-container {
-  min-height: 100vh;
+  min-height: 100dvh;
   background: #101015;
   color: #fafaf8;
   font-family: 'JetBrains Mono', monospace;

--- a/deprecated-claude-app/frontend/src/views/ArchiveView.vue
+++ b/deprecated-claude-app/frontend/src/views/ArchiveView.vue
@@ -275,7 +275,7 @@ onMounted(() => {
 
 <style scoped>
 .archive-view {
-  height: 100vh;
+  height: 100dvh;
   display: flex;
   flex-direction: column;
   background: rgb(var(--v-theme-background));

--- a/deprecated-claude-app/frontend/src/views/ConversationView.vue
+++ b/deprecated-claude-app/frontend/src/views/ConversationView.vue
@@ -280,7 +280,7 @@
     <v-main
       v-if="!isMobile || mobilePanel === 'conversation'"
       class="d-flex flex-column"
-      style="height: 100vh;"
+      style="height: 100dvh;"
     >
       <!-- Top Bar -->
       <v-app-bar density="compact">
@@ -431,7 +431,7 @@
         <v-container
           ref="messagesContainer"
           class="flex-grow-1 overflow-y-auto messages-container"
-          style="max-height: calc(100vh - 160px);"
+          style="max-height: calc(100dvh - 160px);"
         >
           <div v-if="!currentConversation && !isLoadingConversation" class="text-center mt-12">
             <v-icon size="64" color="grey">mdi-message-text-outline</v-icon>

--- a/deprecated-claude-app/frontend/src/views/InviteView.vue
+++ b/deprecated-claude-app/frontend/src/views/InviteView.vue
@@ -231,7 +231,7 @@ onMounted(() => {
 @import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;500&display=swap');
 
 .invite-container {
-  min-height: 100vh;
+  min-height: 100dvh;
   background: #101015;
   color: #fafaf8;
   font-family: 'JetBrains Mono', monospace;

--- a/deprecated-claude-app/frontend/src/views/LoginView.vue
+++ b/deprecated-claude-app/frontend/src/views/LoginView.vue
@@ -584,7 +584,7 @@ async function sendResetEmail() {
 @import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;500&display=swap');
 
 .login-container {
-  min-height: 100vh;
+  min-height: 100dvh;
   background: #101015;
   color: #fafaf8;
   font-family: 'JetBrains Mono', monospace;

--- a/deprecated-claude-app/frontend/src/views/ModelPricingView.vue
+++ b/deprecated-claude-app/frontend/src/views/ModelPricingView.vue
@@ -249,7 +249,7 @@ onMounted(() => {
 
 <style scoped>
 .pricing-page {
-  min-height: 100vh;
+  min-height: 100dvh;
   background: radial-gradient(circle at top, rgba(187, 134, 252, 0.15), transparent 45%),
     #0e0e0e;
   color: #f5f5f5;

--- a/deprecated-claude-app/frontend/src/views/PrivacyView.vue
+++ b/deprecated-claude-app/frontend/src/views/PrivacyView.vue
@@ -292,7 +292,7 @@ const { config: siteConfig, links, operator } = useSiteConfig();
 @import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;500&display=swap');
 
 .legal-container {
-  min-height: 100vh;
+  min-height: 100dvh;
   background: #101015;
   color: #fafaf8;
   font-family: 'JetBrains Mono', monospace;

--- a/deprecated-claude-app/frontend/src/views/ResetPasswordView.vue
+++ b/deprecated-claude-app/frontend/src/views/ResetPasswordView.vue
@@ -173,7 +173,7 @@ async function submitReset() {
 @import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;500&display=swap');
 
 .reset-container {
-  min-height: 100vh;
+  min-height: 100dvh;
   background: #101015;
   color: #fafaf8;
   font-family: 'JetBrains Mono', monospace;

--- a/deprecated-claude-app/frontend/src/views/SharedView.vue
+++ b/deprecated-claude-app/frontend/src/views/SharedView.vue
@@ -45,7 +45,7 @@
     </v-app-bar>
     
     <v-main>
-      <div class="d-flex flex-column" style="height: calc(100vh - 48px);">
+      <div class="d-flex flex-column" style="height: calc(100dvh - 48px);">
         <div v-if="isLoading" class="flex-grow-1 d-flex align-center justify-center">
           <v-progress-circular indeterminate color="primary" />
         </div>

--- a/deprecated-claude-app/frontend/src/views/TermsView.vue
+++ b/deprecated-claude-app/frontend/src/views/TermsView.vue
@@ -218,7 +218,7 @@ const { config: siteConfig, links, operator } = useSiteConfig();
 @import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;500&display=swap');
 
 .legal-container {
-  min-height: 100vh;
+  min-height: 100dvh;
   background: #101015;
   color: #fafaf8;
   font-family: 'JetBrains Mono', monospace;

--- a/deprecated-claude-app/frontend/src/views/VerifyEmailView.vue
+++ b/deprecated-claude-app/frontend/src/views/VerifyEmailView.vue
@@ -154,7 +154,7 @@ async function resendVerification() {
 @import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;500&display=swap');
 
 .verify-container {
-  min-height: 100vh;
+  min-height: 100dvh;
   background: #101015;
   color: #fafaf8;
   font-family: 'JetBrains Mono', monospace;


### PR DESCRIPTION
Two small mobile-related fixes discovered while running the dev server over Tailscale from a phone.

## 1. `100vh` → `100dvh` (14 files, 15 lines)

On mobile, `100vh` counts the area behind the URL bar and bottom navigation chrome, so the chat input bar in `ConversationView` is hidden until the user scrolls to collapse the browser chrome. `100dvh` (dynamic viewport height) accounts for visible chrome and adjusts as it shows/hides.

Supported in Chrome 108+, Safari 15.4+, Firefox 101+ — well within the support floor for a Vue 3 / Vuetify 3 app. Swapped in every full-height view + a few `calc(100vh - …)` cases for consistency.

## 2. Client UUID generation without requiring a secure context

The send button on mobile hung in its loading state forever with no error surfaced. After a long debug session, the root cause was `crypto.randomUUID()` in `store/index.ts`: that API is gated to "secure contexts" — HTTPS origins, plus `localhost`/`127.0.0.1` as special cases. Plain HTTP on a LAN hostname or IP (typical dev: phone → `http://hostname:5173` over Tailscale) is **not** a secure context, so `crypto.randomUUID` is undefined there and calling it throws synchronously. The throw sat just outside the existing try/catch in the send handler, so the UI got stuck.

Added `utils/uuid.ts` with `createClientUuid()`:
1. `crypto.randomUUID()` when available (HTTPS / localhost)
2. `crypto.getRandomValues()` + manual RFC 4122 v4 bit-packing (all browsers, all contexts)
3. `Math.random()` as a last resort

Replaced both `crypto.randomUUID()` call sites in `store/index.ts` (chat send + continue-generation).

Both fixes reproduce in any non-localhost http:// dev setup, not just Tailscale.