### PR TITLE
Add Claude.ai archive bulk importer

### DIFF
--- a/deprecated-claude-app/backend/package.json
+++ b/deprecated-claude-app/backend/package.json
@@ -9,6 +9,7 @@
     "build": "tsc",
     "start": "node dist/index.js",
     "start:https": "USE_HTTPS=true node dist/index.js",
+    "import:claude-archive": "tsx scripts/import-claude-archive.ts",
     "generate-cert": "mkdir -p certs && openssl req -x509 -newkey rsa:4096 -keyout certs/key.pem -out certs/cert.pem -days 365 -nodes -subj '/CN=localhost'"
   },
   "dependencies": {

--- a/deprecated-claude-app/backend/scripts/import-claude-archive.ts
+++ b/deprecated-claude-app/backend/scripts/import-claude-archive.ts
@@ -1,0 +1,168 @@
+#!/usr/bin/env node
+import dotenv from 'dotenv';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import {
+  ClaudeArchiveContentMode,
+  getDefaultClaudeArchiveModel,
+  importClaudeArchive,
+  previewClaudeArchive
+} from '../src/services/claudeArchiveImporter.js';
+
+interface Options {
+  file?: string;
+  email?: string;
+  userId?: string;
+  model: string;
+  dryRun: boolean;
+  limit?: number;
+  skipEmpty: boolean;
+  contentMode: ClaudeArchiveContentMode;
+}
+
+function usage(): never {
+  console.error(`Usage:
+  npm run import:claude-archive -- --file /path/to/conversations.json --email you@example.com [options]
+
+Options:
+  --file <path>                 Claude.ai conversations.json export
+  --email <email>               Arc user email to import into
+  --user-id <uuid>              Arc user id to import into
+  --model <model-id>            Conversation model id (default: ${getDefaultClaudeArchiveModel()})
+  --limit <n>                   Import at most n non-empty conversations
+  --include-empty               Create conversations that have no messages
+  --content <mode>              rendered, text-blocks, or verbose-blocks (default: rendered)
+  --dry-run                     Parse and summarize without writing data
+
+Notes:
+  This command is not idempotent. Re-running it will create another copy of each conversation.
+  Run it from anywhere; it writes to backend/data relative to this package.`);
+  process.exit(1);
+}
+
+function parseArgs(argv: string[]): Options {
+  const options: Options = {
+    model: getDefaultClaudeArchiveModel(),
+    dryRun: false,
+    skipEmpty: true,
+    contentMode: 'rendered'
+  };
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    const next = () => {
+      const value = argv[++i];
+      if (!value) usage();
+      return value;
+    };
+
+    switch (arg) {
+      case '--file':
+        options.file = next();
+        break;
+      case '--email':
+        options.email = next().toLowerCase();
+        break;
+      case '--user-id':
+        options.userId = next();
+        break;
+      case '--model':
+        options.model = next();
+        break;
+      case '--limit':
+        options.limit = Number(next());
+        if (!Number.isInteger(options.limit) || options.limit < 1) usage();
+        break;
+      case '--include-empty':
+        options.skipEmpty = false;
+        break;
+      case '--content': {
+        const mode = next();
+        if (mode !== 'rendered' && mode !== 'text-blocks' && mode !== 'verbose-blocks') usage();
+        options.contentMode = mode;
+        break;
+      }
+      case '--dry-run':
+        options.dryRun = true;
+        break;
+      case '--help':
+      case '-h':
+        usage();
+        break;
+      default:
+        console.error(`Unknown argument: ${arg}`);
+        usage();
+    }
+  }
+
+  if (!options.file) usage();
+  if (!options.dryRun && !options.email && !options.userId) {
+    console.error('Either --email or --user-id is required unless --dry-run is set.');
+    usage();
+  }
+
+  return options;
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+  const backendRoot = path.resolve(scriptDir, '..');
+  const archivePath = path.resolve(options.file!);
+
+  process.chdir(backendRoot);
+  dotenv.config({ path: path.join(backendRoot, '.env') });
+
+  const preview = previewClaudeArchive(archivePath, {
+    skipEmpty: options.skipEmpty,
+    limit: options.limit
+  });
+
+  console.log(`[Claude archive import] Archive: ${archivePath}`);
+  console.log(`[Claude archive import] Selected conversations: ${preview.selectedConversations} of ${preview.totalConversations}`);
+  console.log(`[Claude archive import] Source messages: ${preview.totalMessages}`);
+  console.log(`[Claude archive import] Content mode: ${options.contentMode}`);
+
+  if (options.dryRun) {
+    console.log(`[Claude archive import] Dry run only. Branchy conversations: ${preview.branchyConversations}`);
+    for (const conversation of preview.samples) {
+      console.log(`  - ${conversation.uuid} | ${conversation.title} | ${conversation.messageCount} messages`);
+    }
+    return;
+  }
+
+  const { Database } = await import('../src/database/index.js');
+  const db = new Database();
+  await db.init();
+
+  const user = options.email
+    ? await db.getUserByEmail(options.email)
+    : await db.getUserById(options.userId!);
+  if (!user) {
+    throw new Error(options.email ? `No user found with email ${options.email}` : `No user found with id ${options.userId}`);
+  }
+
+  const result = await importClaudeArchive(db, archivePath, user.id, {
+    model: options.model,
+    skipEmpty: options.skipEmpty,
+    limit: options.limit,
+    contentMode: options.contentMode,
+    onProgress: progress => {
+      if (progress.importedConversations % 25 === 0) {
+        console.log(`[Claude archive import] Imported ${progress.importedConversations}/${progress.totalConversations} conversations...`);
+      }
+    }
+  });
+
+  console.log('[Claude archive import] Done.');
+  console.log(`  User: ${user.email} (${user.id})`);
+  console.log(`  Conversations imported: ${result.importedConversations}`);
+  console.log(`  Conversations skipped: ${result.skippedConversations}`);
+  console.log(`  Arc messages created: ${result.importedMessages}`);
+  console.log(`  Arc branches created: ${result.importedBranches}`);
+}
+
+main().catch(error => {
+  console.error('[Claude archive import] Failed:', error instanceof Error ? error.message : error);
+  process.exit(1);
+});

--- a/deprecated-claude-app/backend/src/database/index.ts
+++ b/deprecated-claude-app/backend/src/database/index.ts
@@ -3384,11 +3384,14 @@ export class Database {
         content: branch.content,
         role: branch.role,
         participantId: branch.participantId,
+        sentByUserId: branch.sentByUserId,
         createdAt: new Date(branch.createdAt),
         model: branch.model,
         // isActive: branch.isActive, // Deprecated field - ignored on import
         parentBranchId: branch.parentBranchId,
-        attachments: branch.attachments
+        attachments: branch.attachments,
+        contentBlocks: branch.contentBlocks,
+        creationSource: branch.creationSource
       })),
       activeBranchId: messageData.activeBranchId,
       order: messageData.order

--- a/deprecated-claude-app/backend/src/routes/import.ts
+++ b/deprecated-claude-app/backend/src/routes/import.ts
@@ -4,7 +4,7 @@ import { v4 as uuidv4 } from 'uuid';
 import multer from 'multer';
 import path from 'path';
 import { mkdirSync } from 'fs';
-import { rm } from 'fs/promises';
+import { rm, readdir, stat } from 'fs/promises';
 import { AuthRequest } from '../middleware/auth.js';
 import { Database } from '../database/index.js';
 import { ImportParser } from '../services/importParser.js';
@@ -40,6 +40,43 @@ interface ClaudeArchiveJob {
 
 const claudeArchiveJobs = new Map<string, ClaudeArchiveJob>();
 const CLAUDE_ARCHIVE_UPLOAD_LIMIT_BYTES = 500 * 1024 * 1024;
+// Uploaded archives can be 100MB+. They are only consumed by an /execute that
+// may never come (dialog closed, backend restarted before execute, etc.), and
+// job state is in-memory so it does not survive a restart anyway. Sweep stale
+// upload files so abandoned previews do not leak disk on the VPS.
+const CLAUDE_ARCHIVE_TMP_TTL_MS = 6 * 60 * 60 * 1000;
+const CLAUDE_ARCHIVE_SWEEP_INTERVAL_MS = 60 * 60 * 1000;
+
+async function sweepStaleClaudeArchiveUploads(uploadDir: string): Promise<void> {
+  let entries: string[];
+  try {
+    entries = await readdir(uploadDir);
+  } catch {
+    return;
+  }
+
+  const activePaths = new Set<string>();
+  for (const job of claudeArchiveJobs.values()) {
+    if (job.status === 'previewed' || job.status === 'running') {
+      activePaths.add(path.resolve(job.filePath));
+    }
+  }
+
+  const now = Date.now();
+  for (const entry of entries) {
+    const fullPath = path.resolve(uploadDir, entry);
+    if (activePaths.has(fullPath)) continue;
+    try {
+      const info = await stat(fullPath);
+      if (!info.isFile()) continue;
+      if (now - info.mtimeMs < CLAUDE_ARCHIVE_TMP_TTL_MS) continue;
+      await rm(fullPath, { force: true });
+      console.log(`[Claude archive import] Swept stale upload ${entry}`);
+    } catch {
+      /* best-effort */
+    }
+  }
+}
 
 function publicClaudeArchiveJob(job: ClaudeArchiveJob) {
   const { filePath: _filePath, ...publicJob } = job;
@@ -57,6 +94,14 @@ export function importRouter(db: Database): Router {
   const parser = new ImportParser();
   const uploadDir = path.resolve(process.cwd(), 'data', 'imports', 'claude-archive');
   mkdirSync(uploadDir, { recursive: true });
+  // Clean orphaned uploads now (covers restart-before-execute) and on an
+  // interval (covers abandoned previews during a long-lived process).
+  void sweepStaleClaudeArchiveUploads(uploadDir);
+  const sweepTimer = setInterval(
+    () => { void sweepStaleClaudeArchiveUploads(uploadDir); },
+    CLAUDE_ARCHIVE_SWEEP_INTERVAL_MS
+  );
+  sweepTimer.unref?.();
   const upload = multer({
     dest: uploadDir,
     limits: {

--- a/deprecated-claude-app/backend/src/routes/import.ts
+++ b/deprecated-claude-app/backend/src/routes/import.ts
@@ -157,7 +157,10 @@ export function importRouter(db: Database): Router {
       if (error instanceof SyntaxError) {
         return res.status(400).json({ error: 'Invalid JSON format' });
       }
-      res.status(500).json({ error: error instanceof Error ? error.message : 'Claude archive preview failed' });
+      // Unrecognized/wrong-file shapes are client errors, not server faults.
+      const message = error instanceof Error ? error.message : 'Claude archive preview failed';
+      const isBadInput = /project file|Unrecognized file|not an array/i.test(message);
+      res.status(isBadInput ? 400 : 500).json({ error: message });
     }
   });
 

--- a/deprecated-claude-app/backend/src/routes/import.ts
+++ b/deprecated-claude-app/backend/src/routes/import.ts
@@ -123,6 +123,13 @@ export function importRouter(db: Database): Router {
 
       const preview = previewClaudeArchive(req.file.path);
       const jobId = uuidv4();
+      console.log(
+        `[claude-archive] preview: user=${req.userId} file="${req.file.originalname}" ` +
+        `${(req.file.size / 1048576).toFixed(1)}MB job=${jobId} -> ` +
+        `${preview.selectedConversations}/${preview.totalConversations} conversations, ` +
+        `${preview.totalMessages} messages, ${preview.branchyConversations} branchy, ` +
+        `${preview.emptyConversations} empty`
+      );
       const job: ClaudeArchiveJob = {
         id: jobId,
         userId: req.userId,
@@ -197,6 +204,7 @@ export function importRouter(db: Database): Router {
         importedBranches: 0
       };
       res.json(publicClaudeArchiveJob(job));
+      console.log(`[claude-archive] execute: job=${job.id} user=${req.userId} model=${model} contentMode=${contentMode}`);
 
       void importClaudeArchive(db, job.filePath, req.userId, {
         model,
@@ -213,9 +221,10 @@ export function importRouter(db: Database): Router {
         job.progress = result;
         job.updatedAt = new Date();
         job.completedAt = new Date();
+        console.log(`[claude-archive] job=${job.id} completed: ${result.importedConversations} conversations imported`);
         await rm(job.filePath, { force: true }).catch(() => undefined);
       }).catch(async error => {
-        console.error('Claude archive execute error:', error);
+        console.error(`[claude-archive] job=${job.id} failed:`, error);
         job.status = 'failed';
         job.error = error instanceof Error ? error.message : 'Claude archive import failed';
         job.updatedAt = new Date();

--- a/deprecated-claude-app/backend/src/routes/import.ts
+++ b/deprecated-claude-app/backend/src/routes/import.ts
@@ -1,17 +1,187 @@
 import { Router } from 'express';
 import { z } from 'zod';
 import { v4 as uuidv4 } from 'uuid';
+import multer from 'multer';
+import path from 'path';
+import { mkdirSync } from 'fs';
+import { rm } from 'fs/promises';
 import { AuthRequest } from '../middleware/auth.js';
 import { Database } from '../database/index.js';
 import { ImportParser } from '../services/importParser.js';
+import {
+  ClaudeArchiveContentMode,
+  ClaudeArchiveImportProgress,
+  ClaudeArchivePreview,
+  getDefaultClaudeArchiveModel,
+  importClaudeArchive,
+  previewClaudeArchive
+} from '../services/claudeArchiveImporter.js';
 import { 
   ImportRequestSchema, 
   ImportFormat
 } from '@deprecated-claude/shared';
 
+type ClaudeArchiveJobStatus = 'previewed' | 'running' | 'completed' | 'failed';
+
+interface ClaudeArchiveJob {
+  id: string;
+  userId: string;
+  filePath: string;
+  originalName: string;
+  status: ClaudeArchiveJobStatus;
+  preview: ClaudeArchivePreview;
+  progress: ClaudeArchiveImportProgress;
+  error?: string;
+  result?: any;
+  createdAt: Date;
+  updatedAt: Date;
+  completedAt?: Date;
+}
+
+const claudeArchiveJobs = new Map<string, ClaudeArchiveJob>();
+const CLAUDE_ARCHIVE_UPLOAD_LIMIT_BYTES = 500 * 1024 * 1024;
+
+function publicClaudeArchiveJob(job: ClaudeArchiveJob) {
+  const { filePath: _filePath, ...publicJob } = job;
+  return publicJob;
+}
+
+function parseClaudeArchiveContentMode(value: unknown): ClaudeArchiveContentMode {
+  return value === 'text-blocks' || value === 'verbose-blocks' || value === 'rendered'
+    ? value
+    : 'rendered';
+}
+
 export function importRouter(db: Database): Router {
   const router = Router();
   const parser = new ImportParser();
+  const uploadDir = path.resolve(process.cwd(), 'data', 'imports', 'claude-archive');
+  mkdirSync(uploadDir, { recursive: true });
+  const upload = multer({
+    dest: uploadDir,
+    limits: {
+      fileSize: CLAUDE_ARCHIVE_UPLOAD_LIMIT_BYTES,
+      files: 1
+    }
+  });
+
+  // Preview a full Claude.ai conversations.json archive without putting the
+  // 100MB+ file through express.json. The authenticated user owns the job.
+  router.post('/claude-archive/preview', upload.single('archive'), async (req: AuthRequest, res) => {
+    try {
+      if (!req.userId) {
+        return res.status(401).json({ error: 'Unauthorized' });
+      }
+      if (!req.file) {
+        return res.status(400).json({ error: 'Archive file is required' });
+      }
+
+      const preview = previewClaudeArchive(req.file.path);
+      const jobId = uuidv4();
+      const job: ClaudeArchiveJob = {
+        id: jobId,
+        userId: req.userId,
+        filePath: req.file.path,
+        originalName: req.file.originalname,
+        status: 'previewed',
+        preview,
+        progress: {
+          importedConversations: 0,
+          totalConversations: preview.selectedConversations,
+          importedMessages: 0,
+          importedBranches: 0
+        },
+        createdAt: new Date(),
+        updatedAt: new Date()
+      };
+
+      claudeArchiveJobs.set(jobId, job);
+      res.json(publicClaudeArchiveJob(job));
+    } catch (error) {
+      if (req.file?.path) {
+        await rm(req.file.path, { force: true }).catch(() => undefined);
+      }
+      console.error('Claude archive preview error:', error);
+      if (error instanceof SyntaxError) {
+        return res.status(400).json({ error: 'Invalid JSON format' });
+      }
+      res.status(500).json({ error: error instanceof Error ? error.message : 'Claude archive preview failed' });
+    }
+  });
+
+  router.get('/claude-archive/:jobId', async (req: AuthRequest, res) => {
+    if (!req.userId) {
+      return res.status(401).json({ error: 'Unauthorized' });
+    }
+
+    const job = claudeArchiveJobs.get(req.params.jobId);
+    if (!job || job.userId !== req.userId) {
+      return res.status(404).json({ error: 'Import job not found' });
+    }
+
+    res.json(publicClaudeArchiveJob(job));
+  });
+
+  router.post('/claude-archive/:jobId/execute', async (req: AuthRequest, res) => {
+    try {
+      if (!req.userId) {
+        return res.status(401).json({ error: 'Unauthorized' });
+      }
+
+      const job = claudeArchiveJobs.get(req.params.jobId);
+      if (!job || job.userId !== req.userId) {
+        return res.status(404).json({ error: 'Import job not found' });
+      }
+      if (job.status !== 'previewed') {
+        return res.status(400).json({ error: `Import job is already ${job.status}` });
+      }
+
+      const model = typeof req.body?.model === 'string' && req.body.model.trim()
+        ? req.body.model.trim()
+        : getDefaultClaudeArchiveModel();
+      const contentMode = parseClaudeArchiveContentMode(req.body?.contentMode);
+      const skipEmpty = req.body?.includeEmpty === true ? false : true;
+      const limit = Number.isInteger(req.body?.limit) && req.body.limit > 0 ? req.body.limit : undefined;
+
+      job.status = 'running';
+      job.updatedAt = new Date();
+      job.progress = {
+        importedConversations: 0,
+        totalConversations: job.preview.selectedConversations,
+        importedMessages: 0,
+        importedBranches: 0
+      };
+      res.json(publicClaudeArchiveJob(job));
+
+      void importClaudeArchive(db, job.filePath, req.userId, {
+        model,
+        skipEmpty,
+        limit,
+        contentMode,
+        onProgress: progress => {
+          job.progress = progress;
+          job.updatedAt = new Date();
+        }
+      }).then(async result => {
+        job.status = 'completed';
+        job.result = result;
+        job.progress = result;
+        job.updatedAt = new Date();
+        job.completedAt = new Date();
+        await rm(job.filePath, { force: true }).catch(() => undefined);
+      }).catch(async error => {
+        console.error('Claude archive execute error:', error);
+        job.status = 'failed';
+        job.error = error instanceof Error ? error.message : 'Claude archive import failed';
+        job.updatedAt = new Date();
+        job.completedAt = new Date();
+        await rm(job.filePath, { force: true }).catch(() => undefined);
+      });
+    } catch (error) {
+      console.error('Claude archive execute setup error:', error);
+      res.status(500).json({ error: error instanceof Error ? error.message : 'Claude archive import failed' });
+    }
+  });
 
   // Preview import
   router.post('/preview', async (req: AuthRequest, res) => {

--- a/deprecated-claude-app/backend/src/services/claudeArchiveImporter.ts
+++ b/deprecated-claude-app/backend/src/services/claudeArchiveImporter.ts
@@ -369,6 +369,14 @@ function buildArcMessages(
     sourceBranchIds.set(message.uuid, uuidv4());
   }
 
+  // Maps a source message uuid -> the Arc branch id its children should
+  // attach to. For an imported message that's its own branch; for a SKIPPED
+  // (empty) message it's whatever its own parent resolved to, so descendants
+  // bridge over the gap to the nearest surviving ancestor instead of a
+  // phantom branch id (which would orphan the entire subtree). Relies on
+  // sortedClaudeMessages emitting parents before children.
+  const effectiveBranchId = new Map<string, string>();
+
   const activeSet = activeSourceUuids(sourceMessages);
   const grouped = new Map<string, ArcRawMessage>();
   const rawMessages: ArcRawMessage[] = [];
@@ -376,7 +384,7 @@ function buildArcMessages(
   for (const source of sortedClaudeMessages(sourceMessages)) {
     const role = roleFor(source.sender);
     const parentBranchId = source.parent_message_uuid
-      ? sourceBranchIds.get(source.parent_message_uuid) || 'root'
+      ? effectiveBranchId.get(source.parent_message_uuid) ?? 'root'
       : 'root';
     const groupKey = `${parentBranchId}:${role}`;
     const branchId = sourceBranchIds.get(source.uuid) || uuidv4();
@@ -384,8 +392,12 @@ function buildArcMessages(
     const built = applyFileReferences(buildMessageContent(source, contentMode), source);
 
     // Skip only if there is genuinely nothing to import (no text AND no
-    // structured thinking blocks).
-    if (!built.content.trim() && !(built.contentBlocks && built.contentBlocks.length)) continue;
+    // structured thinking blocks). Bridge children over the gap: anything
+    // parented to this message should attach to this message's own parent.
+    if (!built.content.trim() && !(built.contentBlocks && built.contentBlocks.length)) {
+      effectiveBranchId.set(source.uuid, parentBranchId);
+      continue;
+    }
 
     let rawMessage = grouped.get(groupKey);
     if (!rawMessage) {
@@ -412,6 +424,9 @@ function buildArcMessages(
       parentBranchId,
       creationSource: 'import'
     });
+
+    // Imported: children attach directly to this message's branch.
+    effectiveBranchId.set(source.uuid, branchId);
 
     // Point the message at the branch that lies on Claude's active path.
     if (activeSet.has(source.uuid)) {

--- a/deprecated-claude-app/backend/src/services/claudeArchiveImporter.ts
+++ b/deprecated-claude-app/backend/src/services/claudeArchiveImporter.ts
@@ -1,0 +1,417 @@
+import { existsSync, readFileSync } from 'fs';
+import { v4 as uuidv4 } from 'uuid';
+import { Database } from '../database/index.js';
+
+type Sender = 'human' | 'assistant';
+
+interface ClaudeContentBlock {
+  type?: string;
+  text?: string;
+  thinking?: string;
+  name?: string;
+  input?: unknown;
+  content?: unknown;
+  display_content?: { text?: string };
+}
+
+interface ClaudeMessage {
+  uuid: string;
+  text?: string;
+  content?: ClaudeContentBlock[];
+  created_at?: string;
+  updated_at?: string;
+  parent_message_uuid?: string | null;
+  sender: Sender | string;
+  attachments?: unknown[];
+  files?: Array<{ file_name?: string; file_uuid?: string }>;
+}
+
+interface ClaudeConversation {
+  uuid: string;
+  name?: string;
+  summary?: string;
+  created_at?: string;
+  updated_at?: string;
+  chat_messages?: ClaudeMessage[];
+}
+
+interface ArcBranch {
+  id: string;
+  content: string;
+  role: 'user' | 'assistant';
+  participantId?: string;
+  sentByUserId?: string;
+  createdAt: Date;
+  model?: string;
+  parentBranchId: string;
+  creationSource: 'import';
+}
+
+interface ArcRawMessage {
+  id: string;
+  conversationId: string;
+  branches: ArcBranch[];
+  activeBranchId: string;
+  order: number;
+}
+
+export type ClaudeArchiveContentMode = 'rendered' | 'text-blocks' | 'verbose-blocks';
+
+export interface ClaudeArchiveImportOptions {
+  model: string;
+  skipEmpty?: boolean;
+  limit?: number;
+  contentMode?: ClaudeArchiveContentMode;
+  onProgress?: (progress: ClaudeArchiveImportProgress) => void | Promise<void>;
+}
+
+export interface ClaudeArchiveImportProgress {
+  importedConversations: number;
+  totalConversations: number;
+  importedMessages: number;
+  importedBranches: number;
+  currentTitle?: string;
+}
+
+export interface ClaudeArchivePreview {
+  totalConversations: number;
+  selectedConversations: number;
+  nonEmptyConversations: number;
+  emptyConversations: number;
+  totalMessages: number;
+  branchyConversations: number;
+  largestConversation?: {
+    uuid: string;
+    title: string;
+    messageCount: number;
+    sizeBytes: number;
+  };
+  samples: Array<{
+    uuid: string;
+    title: string;
+    messageCount: number;
+    createdAt?: string;
+    updatedAt?: string;
+  }>;
+}
+
+export interface ClaudeArchiveImportResult extends ClaudeArchiveImportProgress {
+  skippedConversations: number;
+}
+
+const DEFAULT_CONTENT_MODE: ClaudeArchiveContentMode = 'rendered';
+
+export function getDefaultClaudeArchiveModel(): string {
+  return 'claude-sonnet-4.6-openrouter';
+}
+
+function parseArchive(filePath: string): ClaudeConversation[] {
+  if (!existsSync(filePath)) {
+    throw new Error(`File not found: ${filePath}`);
+  }
+
+  const parsed = JSON.parse(readFileSync(filePath, 'utf8'));
+  if (!Array.isArray(parsed)) {
+    throw new Error('Expected a Claude.ai archive array, but the top-level JSON value is not an array.');
+  }
+
+  return parsed;
+}
+
+function selectedConversations(archive: ClaudeConversation[], skipEmpty = true, limit?: number): ClaudeConversation[] {
+  return archive
+    .filter(conversation => !skipEmpty || (conversation.chat_messages?.length || 0) > 0)
+    .slice(0, limit || undefined);
+}
+
+function roleFor(sender: string): 'user' | 'assistant' {
+  return sender === 'human' ? 'user' : 'assistant';
+}
+
+function dateFrom(value: string | undefined): Date {
+  if (!value) return new Date();
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? new Date() : date;
+}
+
+function renderBlock(block: ClaudeContentBlock): string {
+  switch (block.type) {
+    case 'text':
+      return block.text || '';
+    case 'thinking':
+      return block.thinking ? `<thinking>\n${block.thinking}\n</thinking>` : '';
+    case 'tool_use': {
+      const label = block.name || 'tool';
+      const body = block.input === undefined ? '' : `\n${JSON.stringify(block.input, null, 2)}`;
+      return `<tool_use name="${label}">${body}\n</tool_use>`;
+    }
+    case 'tool_result': {
+      const body = typeof block.content === 'string' ? block.content : JSON.stringify(block.content, null, 2);
+      return `<tool_result name="${block.name || 'tool'}">\n${body || ''}\n</tool_result>`;
+    }
+    case 'token_budget':
+      return '';
+    case 'flag':
+      return '[Claude.ai safety flag omitted]';
+    default:
+      return block.display_content?.text || block.text || '';
+  }
+}
+
+function extractText(message: ClaudeMessage, mode: ClaudeArchiveContentMode): string {
+  if (mode === 'rendered' && typeof message.text === 'string' && message.text.trim()) {
+    return message.text.trim();
+  }
+
+  const blocks = Array.isArray(message.content) ? message.content : [];
+  const rendered = blocks
+    .map(block => {
+      if (mode === 'text-blocks' && block.type !== 'text') return '';
+      return renderBlock(block);
+    })
+    .filter(text => text && text.trim())
+    .join('\n\n')
+    .trim();
+
+  if (rendered) return rendered;
+  return typeof message.text === 'string' ? message.text.trim() : '';
+}
+
+function appendFileReferences(content: string, message: ClaudeMessage): string {
+  const fileNames = (message.files || [])
+    .map(file => file.file_name || file.file_uuid)
+    .filter((name): name is string => !!name);
+
+  if (fileNames.length === 0) return content;
+
+  const suffix = `\n\n[Imported file references: ${fileNames.join(', ')}]`;
+  return content ? `${content}${suffix}` : suffix.trim();
+}
+
+function sortedClaudeMessages(messages: ClaudeMessage[]): ClaudeMessage[] {
+  const byId = new Map<string, ClaudeMessage>();
+  const originalIndex = new Map<string, number>();
+  messages.forEach((message, index) => {
+    byId.set(message.uuid, message);
+    originalIndex.set(message.uuid, index);
+  });
+
+  const sorted: ClaudeMessage[] = [];
+  const visited = new Set<string>();
+  const visiting = new Set<string>();
+
+  function visit(message: ClaudeMessage) {
+    if (visited.has(message.uuid)) return;
+    if (visiting.has(message.uuid)) {
+      console.warn(`[Claude archive import] Cycle detected at message ${message.uuid}; preserving input order for that branch.`);
+      return;
+    }
+
+    visiting.add(message.uuid);
+    const parentId = message.parent_message_uuid || undefined;
+    const parent = parentId ? byId.get(parentId) : undefined;
+    if (parent) visit(parent);
+    visiting.delete(message.uuid);
+    visited.add(message.uuid);
+    sorted.push(message);
+  }
+
+  [...messages]
+    .sort((a, b) => {
+      const timeDelta = dateFrom(a.created_at).getTime() - dateFrom(b.created_at).getTime();
+      if (timeDelta !== 0) return timeDelta;
+      return (originalIndex.get(a.uuid) || 0) - (originalIndex.get(b.uuid) || 0);
+    })
+    .forEach(visit);
+
+  return sorted;
+}
+
+function buildArcMessages(
+  conversationId: string,
+  sourceMessages: ClaudeMessage[],
+  userParticipantId: string | undefined,
+  assistantParticipantId: string | undefined,
+  importingUserId: string,
+  model: string,
+  contentMode: ClaudeArchiveContentMode
+): ArcRawMessage[] {
+  const sourceBranchIds = new Map<string, string>();
+  for (const message of sourceMessages) {
+    sourceBranchIds.set(message.uuid, uuidv4());
+  }
+
+  const grouped = new Map<string, ArcRawMessage>();
+  const rawMessages: ArcRawMessage[] = [];
+
+  for (const source of sortedClaudeMessages(sourceMessages)) {
+    const role = roleFor(source.sender);
+    const parentBranchId = source.parent_message_uuid
+      ? sourceBranchIds.get(source.parent_message_uuid) || 'root'
+      : 'root';
+    const groupKey = `${parentBranchId}:${role}`;
+    const branchId = sourceBranchIds.get(source.uuid) || uuidv4();
+    const participantId = role === 'user' ? userParticipantId : assistantParticipantId;
+    const content = appendFileReferences(extractText(source, contentMode), source);
+
+    if (!content.trim()) continue;
+
+    let rawMessage = grouped.get(groupKey);
+    if (!rawMessage) {
+      rawMessage = {
+        id: uuidv4(),
+        conversationId,
+        branches: [],
+        activeBranchId: branchId,
+        order: rawMessages.length
+      };
+      grouped.set(groupKey, rawMessage);
+      rawMessages.push(rawMessage);
+    }
+
+    rawMessage.branches.push({
+      id: branchId,
+      content,
+      role,
+      participantId,
+      sentByUserId: role === 'user' ? importingUserId : undefined,
+      createdAt: dateFrom(source.created_at),
+      model: role === 'assistant' ? model : undefined,
+      parentBranchId,
+      creationSource: 'import'
+    });
+  }
+
+  return rawMessages;
+}
+
+function titleFor(conversation: ClaudeConversation): string {
+  const title = conversation.name?.trim() || conversation.summary?.trim();
+  if (title) return title;
+  return `Claude import ${conversation.uuid.slice(0, 8)}`;
+}
+
+function isBranchy(conversation: ClaudeConversation): boolean {
+  const parentCounts = new Map<string, number>();
+  for (const message of conversation.chat_messages || []) {
+    const key = `${message.parent_message_uuid || 'root'}:${roleFor(message.sender)}`;
+    parentCounts.set(key, (parentCounts.get(key) || 0) + 1);
+  }
+  return [...parentCounts.values()].some(count => count > 1);
+}
+
+export function previewClaudeArchive(filePath: string, options: Pick<ClaudeArchiveImportOptions, 'skipEmpty' | 'limit'> = {}): ClaudeArchivePreview {
+  const archive = parseArchive(filePath);
+  const selected = selectedConversations(archive, options.skipEmpty ?? true, options.limit);
+  const nonEmptyConversations = archive.filter(conversation => (conversation.chat_messages?.length || 0) > 0).length;
+
+  let largestConversation: ClaudeArchivePreview['largestConversation'];
+  for (const conversation of selected) {
+    const sizeBytes = Buffer.byteLength(JSON.stringify(conversation), 'utf8');
+    const messageCount = conversation.chat_messages?.length || 0;
+    if (!largestConversation || sizeBytes > largestConversation.sizeBytes) {
+      largestConversation = {
+        uuid: conversation.uuid,
+        title: titleFor(conversation),
+        messageCount,
+        sizeBytes
+      };
+    }
+  }
+
+  return {
+    totalConversations: archive.length,
+    selectedConversations: selected.length,
+    nonEmptyConversations,
+    emptyConversations: archive.length - nonEmptyConversations,
+    totalMessages: selected.reduce((sum, conversation) => sum + (conversation.chat_messages?.length || 0), 0),
+    branchyConversations: selected.filter(isBranchy).length,
+    largestConversation,
+    samples: selected.slice(0, 5).map(conversation => ({
+      uuid: conversation.uuid,
+      title: titleFor(conversation),
+      messageCount: conversation.chat_messages?.length || 0,
+      createdAt: conversation.created_at,
+      updatedAt: conversation.updated_at
+    }))
+  };
+}
+
+export async function importClaudeArchive(
+  db: Database,
+  filePath: string,
+  userId: string,
+  options: ClaudeArchiveImportOptions
+): Promise<ClaudeArchiveImportResult> {
+  const archive = parseArchive(filePath);
+  const selected = selectedConversations(archive, options.skipEmpty ?? true, options.limit);
+  const user = await db.getUserById(userId);
+  if (!user) throw new Error(`No user found with id ${userId}`);
+
+  let importedConversations = 0;
+  let importedMessages = 0;
+  let importedBranches = 0;
+  let skippedConversations = 0;
+
+  for (const sourceConversation of selected) {
+    const sourceMessages = sourceConversation.chat_messages || [];
+    if (sourceMessages.length === 0 && (options.skipEmpty ?? true)) {
+      skippedConversations++;
+      continue;
+    }
+
+    const conversation = await db.createConversation(
+      user.id,
+      titleFor(sourceConversation),
+      options.model,
+      undefined,
+      undefined,
+      'standard'
+    );
+
+    const participants = await db.getConversationParticipants(conversation.id, user.id);
+    const userParticipant = participants.find(participant => participant.type === 'user');
+    const assistantParticipant = participants.find(participant => participant.type === 'assistant');
+
+    const rawMessages = buildArcMessages(
+      conversation.id,
+      sourceMessages,
+      userParticipant?.id,
+      assistantParticipant?.id,
+      user.id,
+      options.model,
+      options.contentMode || DEFAULT_CONTENT_MODE
+    );
+
+    for (const rawMessage of rawMessages) {
+      await db.importRawMessage(conversation.id, user.id, rawMessage);
+      importedMessages++;
+      importedBranches += rawMessage.branches.length;
+    }
+
+    await (db as any).logUserEvent(user.id, 'conversation_updated', {
+      id: conversation.id,
+      updates: {
+        createdAt: dateFrom(sourceConversation.created_at),
+        updatedAt: dateFrom(sourceConversation.updated_at || sourceConversation.created_at)
+      }
+    });
+
+    importedConversations++;
+    await options.onProgress?.({
+      importedConversations,
+      totalConversations: selected.length,
+      importedMessages,
+      importedBranches,
+      currentTitle: titleFor(sourceConversation)
+    });
+  }
+
+  return {
+    importedConversations,
+    totalConversations: selected.length,
+    importedMessages,
+    importedBranches,
+    skippedConversations
+  };
+}

--- a/deprecated-claude-app/backend/src/services/claudeArchiveImporter.ts
+++ b/deprecated-claude-app/backend/src/services/claudeArchiveImporter.ts
@@ -120,11 +120,31 @@ function parseArchive(filePath: string): ClaudeConversation[] {
   }
 
   const parsed = JSON.parse(readFileSync(filePath, 'utf8'));
-  if (!Array.isArray(parsed)) {
-    throw new Error('Expected a Claude.ai archive array, but the top-level JSON value is not an array.');
+
+  if (Array.isArray(parsed)) {
+    return parsed;
   }
 
-  return parsed;
+  // A single exported conversation (object with chat_messages) is a valid,
+  // common thing to drag in — accept it by wrapping as a one-item archive.
+  if (parsed && typeof parsed === 'object' && Array.isArray(parsed.chat_messages)) {
+    return [parsed as ClaudeConversation];
+  }
+
+  // A Claude *project* file (prompt_template + docs, no chat_messages) is the
+  // usual mistaken upload — give a precise message instead of "not an array".
+  if (parsed && typeof parsed === 'object' && 'prompt_template' in parsed && 'docs' in parsed) {
+    throw new Error(
+      'This looks like a Claude project file, not a conversations export. ' +
+      'Project files contain knowledge docs, not chat history — upload your ' +
+      'conversations.json (the full archive) or a single exported conversation.'
+    );
+  }
+
+  throw new Error(
+    'Unrecognized file. Expected a Claude.ai conversations.json archive ' +
+    '(an array of conversations) or a single exported conversation object.'
+  );
 }
 
 function selectedConversations(archive: ClaudeConversation[], skipEmpty = true, limit?: number): ClaudeConversation[] {

--- a/deprecated-claude-app/backend/src/services/claudeArchiveImporter.ts
+++ b/deprecated-claude-app/backend/src/services/claudeArchiveImporter.ts
@@ -8,6 +8,7 @@ interface ClaudeContentBlock {
   type?: string;
   text?: string;
   thinking?: string;
+  signature?: string;
   name?: string;
   input?: unknown;
   content?: unknown;
@@ -35,9 +36,17 @@ interface ClaudeConversation {
   chat_messages?: ClaudeMessage[];
 }
 
+interface ArcContentBlock {
+  type: 'thinking' | 'text';
+  thinking?: string;
+  signature?: string;
+  text?: string;
+}
+
 interface ArcBranch {
   id: string;
   content: string;
+  contentBlocks?: ArcContentBlock[];
   role: 'user' | 'assistant';
   participantId?: string;
   sentByUserId?: string;
@@ -134,12 +143,20 @@ function dateFrom(value: string | undefined): Date {
   return Number.isNaN(date.getTime()) ? new Date() : date;
 }
 
-function renderBlock(block: ClaudeContentBlock): string {
+interface BuiltContent {
+  content: string;
+  contentBlocks?: ArcContentBlock[];
+}
+
+// Inline rendering for blocks Arc has no structured representation for
+// (tools, misc). Thinking is intentionally NOT inlined in 'rendered' mode —
+// it becomes a structured thinking contentBlock instead.
+function renderInlineBlock(block: ClaudeContentBlock, includeThinking: boolean): string {
   switch (block.type) {
     case 'text':
       return block.text || '';
     case 'thinking':
-      return block.thinking ? `<thinking>\n${block.thinking}\n</thinking>` : '';
+      return includeThinking && block.thinking ? `<thinking>\n${block.thinking}\n</thinking>` : '';
     case 'tool_use': {
       const label = block.name || 'tool';
       const body = block.input === undefined ? '' : `\n${JSON.stringify(block.input, null, 2)}`;
@@ -158,34 +175,125 @@ function renderBlock(block: ClaudeContentBlock): string {
   }
 }
 
-function extractText(message: ClaudeMessage, mode: ClaudeArchiveContentMode): string {
-  if (mode === 'rendered' && typeof message.text === 'string' && message.text.trim()) {
-    return message.text.trim();
+// Builds display content + (optionally) structured contentBlocks.
+//
+//  - 'rendered' (default): thinking blocks become real {type:'thinking'}
+//    contentBlocks (extended thinking, shown separately), text is the display
+//    content, tools fold into display text. contentBlocks only attached when
+//    the message actually has thinking (keeps simple messages simple).
+//  - 'text-blocks': text only, thinking/tools stripped, no contentBlocks.
+//  - 'verbose-blocks': everything dumped inline as text (archival raw mode),
+//    no structured blocks.
+function buildMessageContent(message: ClaudeMessage, mode: ClaudeArchiveContentMode): BuiltContent {
+  const blocks = Array.isArray(message.content) ? message.content : [];
+  const fallbackText = typeof message.text === 'string' ? message.text.trim() : '';
+
+  if (mode === 'verbose-blocks') {
+    const dumped = blocks
+      .map(block => renderInlineBlock(block, true))
+      .filter(text => text && text.trim())
+      .join('\n\n')
+      .trim();
+    return { content: dumped || fallbackText };
   }
 
-  const blocks = Array.isArray(message.content) ? message.content : [];
-  const rendered = blocks
-    .map(block => {
-      if (mode === 'text-blocks' && block.type !== 'text') return '';
-      return renderBlock(block);
-    })
-    .filter(text => text && text.trim())
-    .join('\n\n')
-    .trim();
+  if (mode === 'text-blocks') {
+    const textOnly = blocks
+      .filter(block => block.type === 'text')
+      .map(block => block.text || '')
+      .filter(text => text.trim())
+      .join('\n\n')
+      .trim();
+    return { content: textOnly || fallbackText };
+  }
 
-  if (rendered) return rendered;
-  return typeof message.text === 'string' ? message.text.trim() : '';
+  // 'rendered'
+  const thinkingBlocks: ArcContentBlock[] = [];
+  const displayParts: string[] = [];
+  for (const block of blocks) {
+    if (block.type === 'thinking') {
+      if (block.thinking && block.thinking.trim()) {
+        thinkingBlocks.push({
+          type: 'thinking',
+          thinking: block.thinking,
+          ...(block.signature ? { signature: block.signature } : {})
+        });
+      }
+      continue;
+    }
+    const rendered = renderInlineBlock(block, false);
+    if (rendered && rendered.trim()) displayParts.push(rendered.trim());
+  }
+
+  let display = displayParts.join('\n\n').trim();
+  if (!display && !thinkingBlocks.length) display = fallbackText;
+
+  if (thinkingBlocks.length === 0) {
+    return { content: display };
+  }
+
+  const contentBlocks: ArcContentBlock[] = [...thinkingBlocks];
+  if (display) contentBlocks.push({ type: 'text', text: display });
+  return { content: display, contentBlocks };
 }
 
-function appendFileReferences(content: string, message: ClaudeMessage): string {
+function applyFileReferences(built: BuiltContent, message: ClaudeMessage): BuiltContent {
   const fileNames = (message.files || [])
     .map(file => file.file_name || file.file_uuid)
     .filter((name): name is string => !!name);
 
-  if (fileNames.length === 0) return content;
+  if (fileNames.length === 0) return built;
 
   const suffix = `\n\n[Imported file references: ${fileNames.join(', ')}]`;
-  return content ? `${content}${suffix}` : suffix.trim();
+  const content = built.content ? `${built.content}${suffix}` : suffix.trim();
+
+  let contentBlocks = built.contentBlocks;
+  if (contentBlocks && contentBlocks.length) {
+    const lastText = [...contentBlocks].reverse().find(b => b.type === 'text');
+    if (lastText) {
+      lastText.text = lastText.text ? `${lastText.text}${suffix}` : suffix.trim();
+    } else {
+      contentBlocks = [...contentBlocks, { type: 'text', text: suffix.trim() }];
+    }
+  }
+
+  return { content, contentBlocks };
+}
+
+// The bulk conversations.json archive has no current_leaf_message_uuid, so we
+// pick the active path the way Claude.ai effectively does: the most recent
+// leaf, walked back to the root. Returns the set of source message uuids that
+// lie on that active path.
+function activeSourceUuids(messages: ClaudeMessage[]): Set<string> {
+  const active = new Set<string>();
+  if (messages.length === 0) return active;
+
+  const byId = new Map<string, ClaudeMessage>();
+  const hasChild = new Set<string>();
+  for (const message of messages) {
+    byId.set(message.uuid, message);
+  }
+  for (const message of messages) {
+    const parentId = message.parent_message_uuid;
+    if (parentId && byId.has(parentId)) hasChild.add(parentId);
+  }
+
+  const leaves = messages.filter(message => !hasChild.has(message.uuid));
+  leaves.sort((a, b) => {
+    const at = dateFrom(a.updated_at || a.created_at).getTime();
+    const bt = dateFrom(b.updated_at || b.created_at).getTime();
+    return bt - at;
+  });
+
+  let current: ClaudeMessage | undefined = leaves[0];
+  let guard = 0;
+  while (current && guard++ <= messages.length) {
+    if (active.has(current.uuid)) break;
+    active.add(current.uuid);
+    const parentId: string | null | undefined = current.parent_message_uuid;
+    current = parentId ? byId.get(parentId) : undefined;
+  }
+  return active;
 }
 
 function sortedClaudeMessages(messages: ClaudeMessage[]): ClaudeMessage[] {
@@ -241,6 +349,7 @@ function buildArcMessages(
     sourceBranchIds.set(message.uuid, uuidv4());
   }
 
+  const activeSet = activeSourceUuids(sourceMessages);
   const grouped = new Map<string, ArcRawMessage>();
   const rawMessages: ArcRawMessage[] = [];
 
@@ -252,9 +361,11 @@ function buildArcMessages(
     const groupKey = `${parentBranchId}:${role}`;
     const branchId = sourceBranchIds.get(source.uuid) || uuidv4();
     const participantId = role === 'user' ? userParticipantId : assistantParticipantId;
-    const content = appendFileReferences(extractText(source, contentMode), source);
+    const built = applyFileReferences(buildMessageContent(source, contentMode), source);
 
-    if (!content.trim()) continue;
+    // Skip only if there is genuinely nothing to import (no text AND no
+    // structured thinking blocks).
+    if (!built.content.trim() && !(built.contentBlocks && built.contentBlocks.length)) continue;
 
     let rawMessage = grouped.get(groupKey);
     if (!rawMessage) {
@@ -271,7 +382,8 @@ function buildArcMessages(
 
     rawMessage.branches.push({
       id: branchId,
-      content,
+      content: built.content,
+      ...(built.contentBlocks ? { contentBlocks: built.contentBlocks } : {}),
       role,
       participantId,
       sentByUserId: role === 'user' ? importingUserId : undefined,
@@ -280,6 +392,11 @@ function buildArcMessages(
       parentBranchId,
       creationSource: 'import'
     });
+
+    // Point the message at the branch that lies on Claude's active path.
+    if (activeSet.has(source.uuid)) {
+      rawMessage.activeBranchId = branchId;
+    }
   }
 
   return rawMessages;
@@ -389,13 +506,11 @@ export async function importClaudeArchive(
       importedBranches += rawMessage.branches.length;
     }
 
-    await (db as any).logUserEvent(user.id, 'conversation_updated', {
-      id: conversation.id,
-      updates: {
-        createdAt: dateFrom(sourceConversation.created_at),
-        updatedAt: dateFrom(sourceConversation.updated_at || sourceConversation.created_at)
-      }
-    });
+    // Reconcile the active branch path so getVisibleMessages renders the
+    // canonical thread (parity with the arc_chat import path). Per-message
+    // time is preserved on each branch.createdAt; the conversation itself
+    // intentionally keeps its import-time created/updated timestamps.
+    await db.alignActiveBranchPath(conversation.id, user.id);
 
     importedConversations++;
     await options.onProgress?.({

--- a/deprecated-claude-app/backend/src/services/claudeArchiveImporter.ts
+++ b/deprecated-claude-app/backend/src/services/claudeArchiveImporter.ts
@@ -460,10 +460,17 @@ export async function importClaudeArchive(
   userId: string,
   options: ClaudeArchiveImportOptions
 ): Promise<ClaudeArchiveImportResult> {
+  const startedAt = Date.now();
   const archive = parseArchive(filePath);
   const selected = selectedConversations(archive, options.skipEmpty ?? true, options.limit);
   const user = await db.getUserById(userId);
   if (!user) throw new Error(`No user found with id ${userId}`);
+
+  console.log(
+    `[claude-archive] import start: user=${userId} selected=${selected.length}/${archive.length} ` +
+    `model=${options.model} contentMode=${options.contentMode || DEFAULT_CONTENT_MODE} ` +
+    `skipEmpty=${options.skipEmpty ?? true}${options.limit ? ` limit=${options.limit}` : ''}`
+  );
 
   let importedConversations = 0;
   let importedMessages = 0;
@@ -513,6 +520,12 @@ export async function importClaudeArchive(
     await db.alignActiveBranchPath(conversation.id, user.id);
 
     importedConversations++;
+    if (importedConversations % 100 === 0 || importedConversations === selected.length) {
+      console.log(
+        `[claude-archive] progress: ${importedConversations}/${selected.length} conversations, ` +
+        `${importedMessages} messages, ${importedBranches} branches`
+      );
+    }
     await options.onProgress?.({
       importedConversations,
       totalConversations: selected.length,
@@ -521,6 +534,13 @@ export async function importClaudeArchive(
       currentTitle: titleFor(sourceConversation)
     });
   }
+
+  console.log(
+    `[claude-archive] import done: user=${userId} ` +
+    `${importedConversations} conversations, ${importedMessages} messages, ` +
+    `${importedBranches} branches, ${skippedConversations} skipped, ` +
+    `${((Date.now() - startedAt) / 1000).toFixed(1)}s`
+  );
 
   return {
     importedConversations,

--- a/deprecated-claude-app/frontend/src/components/ImportDialogV2.vue
+++ b/deprecated-claude-app/frontend/src/components/ImportDialogV2.vue
@@ -108,6 +108,48 @@
 
           <!-- Step 2: Preview & Participant Mapping -->
           <v-stepper-window-item :value="2">
+            <v-card-text v-if="isClaudeArchiveFormat && archiveJob">
+              <h4 class="text-h6 mb-4">Archive Preview</h4>
+
+              <v-row dense>
+                <v-col cols="6" sm="3">
+                  <div class="text-caption text-grey">Conversations</div>
+                  <div class="text-h6">{{ archiveJob.preview.selectedConversations }}</div>
+                </v-col>
+                <v-col cols="6" sm="3">
+                  <div class="text-caption text-grey">Messages</div>
+                  <div class="text-h6">{{ archiveJob.preview.totalMessages }}</div>
+                </v-col>
+                <v-col cols="6" sm="3">
+                  <div class="text-caption text-grey">Branches</div>
+                  <div class="text-h6">{{ archiveJob.preview.branchyConversations }}</div>
+                </v-col>
+                <v-col cols="6" sm="3">
+                  <div class="text-caption text-grey">Skipped Empty</div>
+                  <div class="text-h6">{{ archiveJob.preview.emptyConversations }}</div>
+                </v-col>
+              </v-row>
+
+              <v-alert
+                type="info"
+                variant="tonal"
+                density="compact"
+                class="mt-4"
+              >
+                {{ archiveJob.originalName }} will be imported as separate conversations owned by your account.
+              </v-alert>
+
+              <v-list density="compact" class="mt-4">
+                <v-list-subheader>Sample Conversations</v-list-subheader>
+                <v-list-item
+                  v-for="sample in archiveJob.preview.samples"
+                  :key="sample.uuid"
+                  :title="sample.title"
+                  :subtitle="`${sample.messageCount} messages`"
+                />
+              </v-list>
+            </v-card-text>
+
             <v-card-text v-if="preview">
               <h4 class="text-h6 mb-4">Preview</h4>
               
@@ -262,6 +304,94 @@
 
           <!-- Step 3: Configuration -->
           <v-stepper-window-item :value="3">
+            <template v-if="isClaudeArchiveFormat">
+              <v-card-text>
+                <v-select
+                  v-model="archiveModel"
+                  :items="activeModels"
+                  item-title="displayName"
+                  item-value="id"
+                  label="Model"
+                  variant="outlined"
+                  density="compact"
+                />
+
+                <v-select
+                  v-model="archiveContentMode"
+                  :items="archiveContentModeOptions"
+                  item-title="label"
+                  item-value="value"
+                  label="Content Mode"
+                  variant="outlined"
+                  density="compact"
+                  class="mt-4"
+                />
+
+                <v-checkbox
+                  v-model="archiveIncludeEmpty"
+                  label="Include empty conversations"
+                  density="compact"
+                  hide-details
+                  class="mt-2"
+                />
+
+                <v-alert
+                  v-if="archiveImportJob"
+                  :type="archiveImportJob.status === 'failed' ? 'error' : archiveImportJob.status === 'completed' ? 'success' : 'info'"
+                  variant="tonal"
+                  density="compact"
+                  class="mt-4"
+                >
+                  <template v-if="archiveImportJob.status === 'failed'">
+                    {{ archiveImportJob.error || 'Import failed' }}
+                  </template>
+                  <template v-else-if="archiveImportJob.status === 'completed'">
+                    Imported {{ archiveImportJob.progress.importedConversations }} conversations.
+                  </template>
+                  <template v-else>
+                    Importing {{ archiveImportJob.progress.importedConversations }} of {{ archiveImportJob.progress.totalConversations }} conversations
+                  </template>
+                </v-alert>
+
+                <v-progress-linear
+                  v-if="archiveImportJob && archiveImportJob.status === 'running'"
+                  :model-value="archiveProgressPercent"
+                  color="primary"
+                  height="8"
+                  rounded
+                  class="mt-3"
+                />
+              </v-card-text>
+
+              <v-card-actions>
+                <v-btn
+                  variant="text"
+                  :disabled="archiveImportJob?.status === 'running'"
+                  @click="step = 2"
+                >
+                  Back
+                </v-btn>
+                <v-spacer />
+                <v-btn
+                  variant="text"
+                  :disabled="archiveImportJob?.status === 'running'"
+                  @click="close"
+                >
+                  Cancel
+                </v-btn>
+                <v-btn
+                  :loading="loading || archiveImportJob?.status === 'running'"
+                  :disabled="!archiveModel || archiveImportJob?.status === 'completed'"
+                  color="primary"
+                  variant="elevated"
+                  @click="executeImport"
+                >
+                  Import Archive
+                </v-btn>
+              </v-card-actions>
+            </template>
+
+            <template v-else>
             <v-card-text>
               <v-text-field
                 v-model="conversationTitle"
@@ -337,6 +467,7 @@
                 Import
               </v-btn>
             </v-card-actions>
+            </template>
           </v-stepper-window-item>
         </v-stepper-window>
       </v-stepper>
@@ -356,6 +487,44 @@ import type {
   Model 
 } from '@deprecated-claude/shared';
 
+type ImportFormatOption = ImportFormat | 'claude_archive';
+type ClaudeArchiveContentMode = 'rendered' | 'text-blocks' | 'verbose-blocks';
+
+interface ClaudeArchiveJob {
+  id: string;
+  originalName: string;
+  status: 'previewed' | 'running' | 'completed' | 'failed';
+  preview: {
+    totalConversations: number;
+    selectedConversations: number;
+    nonEmptyConversations: number;
+    emptyConversations: number;
+    totalMessages: number;
+    branchyConversations: number;
+    samples: Array<{
+      uuid: string;
+      title: string;
+      messageCount: number;
+      createdAt?: string;
+      updatedAt?: string;
+    }>;
+    largestConversation?: {
+      uuid: string;
+      title: string;
+      messageCount: number;
+      sizeBytes: number;
+    };
+  };
+  progress: {
+    importedConversations: number;
+    totalConversations: number;
+    importedMessages: number;
+    importedBranches: number;
+    currentTitle?: string;
+  };
+  error?: string;
+}
+
 const props = defineProps<{
   modelValue: boolean;
 }>();
@@ -371,8 +540,8 @@ const router = useRouter();
 const step = ref(1);
 
 // Step 1: Format selection
-const selectedFormat = ref<ImportFormat | null>(null);
-const file = ref<File | null>(null);
+const selectedFormat = ref<ImportFormatOption | null>(null);
+const file = ref<File | File[] | null>(null);
 const textContent = ref('');
 const fileContent = ref('');
 
@@ -381,11 +550,17 @@ const preview = ref<ImportPreview | null>(null);
 const participantMappings = ref<Record<string, ParticipantMapping>>({});
 const editableParticipants = ref<Array<{ sourceName: string; targetName: string; type: 'user' | 'assistant' }>>([]);
 const reparsingPreview = ref(false);
+const archiveJob = ref<ClaudeArchiveJob | null>(null);
+const archiveImportJob = ref<ClaudeArchiveJob | null>(null);
+const archivePollTimer = ref<number | null>(null);
 
 // Step 3: Configuration
 const conversationTitle = ref('');
 const conversationFormat = ref<'standard' | 'prefill'>('standard');
 const selectedModel = ref('');
+const archiveModel = ref('');
+const archiveContentMode = ref<ClaudeArchiveContentMode>('rendered');
+const archiveIncludeEmpty = ref(false);
 
 // UI state
 const error = ref('');
@@ -393,6 +568,11 @@ const loading = ref(false);
 
 // Format options
 const formatOptions = [
+  {
+    value: 'claude_archive',
+    label: 'Claude.ai Archive',
+    description: 'Bulk import a full Claude.ai conversations.json export'
+  },
   {
     value: 'chrome_extension',
     label: 'Claude Conversation Exporter',
@@ -441,6 +621,7 @@ const formatOptions = [
 ];
 
 const formatLabels: Record<string, string> = {
+  claude_archive: 'Claude.ai archive',
   basic_json: 'JSON',
   anthropic: 'Anthropic',
   chrome_extension: 'Claude Conversation Exporter',
@@ -465,6 +646,21 @@ const conversationFormatOptions = [
   }
 ];
 
+const archiveContentModeOptions = [
+  {
+    value: 'rendered',
+    label: 'Rendered text'
+  },
+  {
+    value: 'text-blocks',
+    label: 'Text blocks only'
+  },
+  {
+    value: 'verbose-blocks',
+    label: 'Verbose blocks'
+  }
+];
+
 // Computed properties
 const models = computed(() => store.state.models);
 
@@ -477,8 +673,11 @@ const isTextFormat = computed(() =>
   selectedFormat.value === 'colon_double'
 );
 
+const isClaudeArchiveFormat = computed(() => selectedFormat.value === 'claude_archive');
+
 const acceptedFileTypes = computed(() => {
-  if (selectedFormat.value === 'basic_json' || 
+  if (selectedFormat.value === 'claude_archive' ||
+      selectedFormat.value === 'basic_json' ||
       selectedFormat.value === 'anthropic' ||
       selectedFormat.value === 'chrome_extension' ||
       selectedFormat.value === 'arc_chat' ||
@@ -494,6 +693,7 @@ const acceptedFileTypes = computed(() => {
 
 const canProceedToPreview = computed(() => {
   if (!selectedFormat.value) return false;
+  if (isClaudeArchiveFormat.value) return !!getSelectedFile();
   if (isTextFormat.value) return textContent.value.trim().length > 0;
   return fileContent.value.length > 0;
 });
@@ -502,12 +702,29 @@ const hasMultipleParticipants = computed(() =>
   (preview.value?.detectedParticipants.length || 0) > 2
 );
 
+const archiveProgressPercent = computed(() => {
+  const progress = archiveImportJob.value?.progress;
+  if (!progress || progress.totalConversations === 0) return 0;
+  return Math.round((progress.importedConversations / progress.totalConversations) * 100);
+});
+
 // Methods
+function getSelectedFile(): File | null {
+  if (!file.value) return null;
+  return Array.isArray(file.value) ? file.value[0] || null : file.value;
+}
+
 async function readFile() {
-  if (!file.value) return;
+  if (isClaudeArchiveFormat.value) {
+    fileContent.value = '';
+    return;
+  }
+
+  const selectedFile = getSelectedFile();
+  if (!selectedFile) return;
   
   try {
-    fileContent.value = await file.value.text();
+    fileContent.value = await selectedFile.text();
   } catch (err: any) {
     error.value = 'Failed to read file';
     fileContent.value = '';
@@ -526,6 +743,11 @@ async function previewImport() {
       await store.loadModels();
     }
     
+    if (isClaudeArchiveFormat.value) {
+      await previewClaudeArchive();
+      return;
+    }
+
     const content = isTextFormat.value ? textContent.value : fileContent.value;
     
     const response = await api.post('/import/preview', {
@@ -604,8 +826,35 @@ async function previewImport() {
   }
 }
 
+async function previewClaudeArchive() {
+  const selectedFile = getSelectedFile();
+  if (!selectedFile) {
+    error.value = 'Select a Claude.ai archive file';
+    return;
+  }
+
+  const formData = new FormData();
+  formData.append('archive', selectedFile);
+
+  const response = await api.post('/import/claude-archive/preview', formData, {
+    headers: { 'Content-Type': 'multipart/form-data' }
+  });
+
+  archiveJob.value = response.data;
+  archiveImportJob.value = null;
+  archiveModel.value = activeModels.value.find(m => m.id === 'claude-sonnet-4.6-openrouter')?.id || activeModels.value[0]?.id || '';
+  step.value = 2;
+}
+
 async function executeImport() {
-  if (!selectedFormat.value || !preview.value) return;
+  if (!selectedFormat.value) return;
+
+  if (isClaudeArchiveFormat.value) {
+    await executeClaudeArchiveImport();
+    return;
+  }
+
+  if (!preview.value) return;
   
   loading.value = true;
   error.value = '';
@@ -644,6 +893,55 @@ async function executeImport() {
     error.value = err.response?.data?.error || 'Failed to import conversation';
   } finally {
     loading.value = false;
+  }
+}
+
+async function executeClaudeArchiveImport() {
+  if (!archiveJob.value) return;
+
+  loading.value = true;
+  error.value = '';
+
+  try {
+    const response = await api.post(`/import/claude-archive/${archiveJob.value.id}/execute`, {
+      model: archiveModel.value,
+      contentMode: archiveContentMode.value,
+      includeEmpty: archiveIncludeEmpty.value
+    });
+    archiveImportJob.value = response.data;
+    startArchivePolling(response.data.id);
+  } catch (err: any) {
+    error.value = err.response?.data?.error || 'Failed to start archive import';
+  } finally {
+    loading.value = false;
+  }
+}
+
+function startArchivePolling(jobId: string) {
+  stopArchivePolling();
+  archivePollTimer.value = window.setInterval(async () => {
+    try {
+      const response = await api.get(`/import/claude-archive/${jobId}`);
+      archiveImportJob.value = response.data;
+
+      if (response.data.status === 'completed') {
+        stopArchivePolling();
+        await store.loadConversations();
+      } else if (response.data.status === 'failed') {
+        stopArchivePolling();
+        error.value = response.data.error || 'Archive import failed';
+      }
+    } catch (err: any) {
+      stopArchivePolling();
+      error.value = err.response?.data?.error || 'Failed to poll archive import';
+    }
+  }, 1500);
+}
+
+function stopArchivePolling() {
+  if (archivePollTimer.value !== null) {
+    window.clearInterval(archivePollTimer.value);
+    archivePollTimer.value = null;
   }
 }
 
@@ -708,17 +1006,23 @@ async function reparseWithCurrentParticipants() {
 }
 
 function close() {
+  stopArchivePolling();
   step.value = 1;
   selectedFormat.value = null;
   file.value = null;
   textContent.value = '';
   fileContent.value = '';
   preview.value = null;
+  archiveJob.value = null;
+  archiveImportJob.value = null;
   participantMappings.value = {};
   editableParticipants.value = [];
   conversationTitle.value = '';
   conversationFormat.value = 'standard';
   selectedModel.value = '';
+  archiveModel.value = '';
+  archiveContentMode.value = 'rendered';
+  archiveIncludeEmpty.value = false;
   error.value = '';
   emit('update:modelValue', false);
 }

--- a/deprecated-claude-app/frontend/src/components/ImportDialogV2.vue
+++ b/deprecated-claude-app/frontend/src/components/ImportDialogV2.vue
@@ -121,7 +121,7 @@
                   <div class="text-h6">{{ archiveJob.preview.totalMessages }}</div>
                 </v-col>
                 <v-col cols="6" sm="3">
-                  <div class="text-caption text-grey">Branches</div>
+                  <div class="text-caption text-grey">Branchy convs</div>
                   <div class="text-h6">{{ archiveJob.preview.branchyConversations }}</div>
                 </v-col>
                 <v-col cols="6" sm="3">
@@ -927,6 +927,9 @@ function startArchivePolling(jobId: string) {
       if (response.data.status === 'completed') {
         stopArchivePolling();
         await store.loadConversations();
+        // Let the success state render briefly, then exit cleanly so the
+        // user lands back on the (now-populated) sidebar.
+        window.setTimeout(() => { close(); }, 1500);
       } else if (response.data.status === 'failed') {
         stopArchivePolling();
         error.value = response.data.error || 'Archive import failed';

--- a/deprecated-claude-app/frontend/src/components/ImportDialogV2.vue
+++ b/deprecated-claude-app/frontend/src/components/ImportDialogV2.vue
@@ -77,6 +77,27 @@
               </div>
 
               <v-alert
+                v-if="isClaudeArchiveFormat && archiveUploading"
+                type="info"
+                variant="tonal"
+                density="compact"
+                class="mt-4"
+              >
+                <div class="mb-2">
+                  {{ archiveUploadPct < 100
+                    ? `Uploading archive… ${archiveUploadPct}%`
+                    : 'Upload complete — parsing on the server. Large exports can take a minute…' }}
+                </div>
+                <v-progress-linear
+                  :model-value="archiveUploadPct"
+                  :indeterminate="archiveUploadPct >= 100"
+                  color="primary"
+                  height="6"
+                  rounded
+                />
+              </v-alert>
+
+              <v-alert
                 v-if="error"
                 type="error"
                 class="mt-4"
@@ -96,7 +117,8 @@
                 Cancel
               </v-btn>
               <v-btn
-                :disabled="!canProceedToPreview"
+                :disabled="!canProceedToPreview || archiveUploading"
+                :loading="loading || archiveUploading"
                 color="primary"
                 variant="elevated"
                 @click="previewImport"
@@ -553,6 +575,8 @@ const reparsingPreview = ref(false);
 const archiveJob = ref<ClaudeArchiveJob | null>(null);
 const archiveImportJob = ref<ClaudeArchiveJob | null>(null);
 const archivePollTimer = ref<number | null>(null);
+const archiveUploading = ref(false);
+const archiveUploadPct = ref(0);
 
 // Step 3: Configuration
 const conversationTitle = ref('');
@@ -836,14 +860,23 @@ async function previewClaudeArchive() {
   const formData = new FormData();
   formData.append('archive', selectedFile);
 
-  const response = await api.post('/import/claude-archive/preview', formData, {
-    headers: { 'Content-Type': 'multipart/form-data' }
-  });
+  archiveUploading.value = true;
+  archiveUploadPct.value = 0;
+  try {
+    const response = await api.post('/import/claude-archive/preview', formData, {
+      headers: { 'Content-Type': 'multipart/form-data' },
+      onUploadProgress: (e: any) => {
+        if (e.total) archiveUploadPct.value = Math.round((e.loaded / e.total) * 100);
+      }
+    });
 
-  archiveJob.value = response.data;
-  archiveImportJob.value = null;
-  archiveModel.value = activeModels.value.find(m => m.id === 'claude-sonnet-4.6-openrouter')?.id || activeModels.value[0]?.id || '';
-  step.value = 2;
+    archiveJob.value = response.data;
+    archiveImportJob.value = null;
+    archiveModel.value = activeModels.value.find(m => m.id === 'claude-sonnet-4.6-openrouter')?.id || activeModels.value[0]?.id || '';
+    step.value = 2;
+  } finally {
+    archiveUploading.value = false;
+  }
 }
 
 async function executeImport() {
@@ -927,9 +960,9 @@ function startArchivePolling(jobId: string) {
       if (response.data.status === 'completed') {
         stopArchivePolling();
         await store.loadConversations();
-        // Let the success state render briefly, then exit cleanly so the
-        // user lands back on the (now-populated) sidebar.
-        window.setTimeout(() => { close(); }, 1500);
+        // Close immediately; the populated sidebar is the success signal.
+        // State resets only after the dialog has hidden, so no bounce.
+        close();
       } else if (response.data.status === 'failed') {
         stopArchivePolling();
         error.value = response.data.error || 'Archive import failed';
@@ -1008,8 +1041,7 @@ async function reparseWithCurrentParticipants() {
   }
 }
 
-function close() {
-  stopArchivePolling();
+function resetState() {
   step.value = 1;
   selectedFormat.value = null;
   file.value = null;
@@ -1018,6 +1050,8 @@ function close() {
   preview.value = null;
   archiveJob.value = null;
   archiveImportJob.value = null;
+  archiveUploading.value = false;
+  archiveUploadPct.value = 0;
   participantMappings.value = {};
   editableParticipants.value = [];
   conversationTitle.value = '';
@@ -1027,13 +1061,23 @@ function close() {
   archiveContentMode.value = 'rendered';
   archiveIncludeEmpty.value = false;
   error.value = '';
+}
+
+// Only request the close here. Internal state is reset AFTER the dialog has
+// actually hidden (see the modelValue watcher) so the user never sees the
+// stepper snap back to step 1 mid-fade ("bounce back to preview").
+function close() {
+  stopArchivePolling();
   emit('update:modelValue', false);
 }
 
-// Load models when dialog opens
 watch(() => props.modelValue, async (isOpen) => {
   if (isOpen && models.value.length === 0) {
     await store.loadModels();
+  }
+  if (!isOpen) {
+    // Wait out the v-dialog fade-out transition before wiping state.
+    window.setTimeout(resetState, 350);
   }
 });
 </script>


### PR DESCRIPTION
## Summary
- add a reusable Claude.ai archive importer service and CLI for full conversations.json exports
- add authenticated multipart upload, preview, async execute, and polling endpoints for per-user bulk imports
- add a Claude.ai Archive option to the import dialog with summary preview, model/content options, and progress polling

## Validation
- npm run import:claude-archive -w backend -- --file /home/jake/personal/conversations.json --dry-run
- isolated one-conversation import into a throwaway /tmp backend data directory
- npm run build