### PR TITLE
Enter inserts a newline; Cmd/Ctrl+Enter sends

### DIFF
--- a/deprecated-claude-app/frontend/src/views/ConversationView.vue
+++ b/deprecated-claude-app/frontend/src/views/ConversationView.vue
@@ -653,13 +653,14 @@
             ref="messageTextarea"
             v-model="messageInput"
             :label="typingIndicatorLabel"
-            placeholder="Type your message..."
+            placeholder="Type your message…  (⌘/Ctrl+Enter to send)"
             rows="1"
             auto-grow
             max-rows="15"
             variant="outlined"
             hide-details
-            @keydown.enter.exact.prevent="sendMessage"
+            @keydown.enter.meta.prevent="sendMessage"
+            @keydown.enter.ctrl.prevent="sendMessage"
             @focus="handleTextareaFocus"
             @paste="handlePaste"
             @input="handleTypingInput"


### PR DESCRIPTION
## Why

Enter-to-send biases the input toward short, chat-style messages. It's especially bad on **mobile**: Shift+Enter isn't available there, and `@keydown.enter.exact.prevent` was hijacking the soft-keyboard return key — so on mobile there was *no way to insert a newline at all*.

## Change

`ConversationView.vue` message input:

- Plain **Enter** (and the mobile return key) now inserts a newline — default textarea behavior, no longer intercepted.
- **Cmd+Enter** (macOS) / **Ctrl+Enter** (Linux/Windows) sends.
- **Mobile/touch** sends via the existing Send button (`mdi-send`, already `touch-action: manipulation`).
- Placeholder advertises the send chord for discoverability.
- Side benefit: removes a latent IME mis-fire — plain Enter is no longer captured mid-composition (CJK input).

## Scope

Single file, +3/-2. Opinionated, no toggle — intentionally a clean behavioral change; take it or leave it. `npm run build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)