### PR TITLE
fix(cost-tracker): four-channel cost computation + provider-truth passthrough

### DIFF
--- a/deprecated-claude-app/backend/src/config/types.ts
+++ b/deprecated-claude-app/backend/src/config/types.ts
@@ -2,6 +2,8 @@
  * Configuration types for API provider profiles
  */
 
+import type { CachePricingMultipliers } from '@deprecated-claude/shared';
+
 export interface ModelCost {
   modelId: string;
   // What we pay to the provider
@@ -14,6 +16,13 @@ export interface ModelCost {
     inputTokensPerMillion: number;
     outputTokensPerMillion: number;
   };
+  /**
+   * Per-channel cache/thinking multipliers, applied to `providerCost` rates.
+   * Falls back to DEFAULT_ANTHROPIC_CACHE_MULTIPLIERS when omitted — correct for
+   * all Anthropic models (direct, via Bedrock, and via OpenRouter). Override
+   * per-model only when the provider's cache pricing genuinely differs.
+   */
+  cachePricing?: CachePricingMultipliers;
 }
 
 export interface ApiKeyProfile {

--- a/deprecated-claude-app/backend/src/database/index.ts
+++ b/deprecated-claude-app/backend/src/database/index.ts
@@ -1,4 +1,4 @@
-import { User, Conversation, Message, MessageBranch, Participant, ApiKey, Bookmark, UserDefinedModel, GrantInfo, GrantCapability, UserGrantSummary, GrantUsageDetails, Invite, getValidatedModelDefaults } from '@deprecated-claude/shared';
+import { User, Conversation, Message, MessageBranch, Participant, ApiKey, Bookmark, UserDefinedModel, GrantInfo, GrantCapability, UserGrantSummary, GrantUsageDetails, Invite, getValidatedModelDefaults, ChannelTokens } from '@deprecated-claude/shared';
 import { TotalsMetrics, TotalsMetricsSchema, ModelConversationMetrics, ModelConversationMetricsSchema } from '@deprecated-claude/shared';
 import { v4 as uuidv4 } from 'uuid';
 import bcrypt from 'bcrypt';
@@ -28,12 +28,20 @@ import {
 } from '@deprecated-claude/shared';
 import { encryption } from '../utils/encryption.js';
 
-// Metrics interface for tracking token usage
+// Metrics interface for tracking token usage.
+//
+// Persisted to the JSONL event log as `metrics_added.metrics`. All fields below
+// the legacy block are additive — old events that lack them replay fine, and
+// downstream readers that don't recognise them ignore them. The raw `tokens`
+// block is the source of truth; `computedCost` is the cached result of running
+// the pricing table over those tokens at write time; `providerReportedCost` is
+// authoritative when present (currently OpenRouter via `usage.cost`).
 export interface MetricsData {
+  // --- Legacy fields (display contract — unchanged) ---
   inputTokens: number;
   outputTokens: number;
   cachedTokens: number;
-  cost: number;
+  cost: number;          // = providerReportedCost ?? computedCost
   cacheSavings: number;
   model: string;
   timestamp: string;
@@ -41,6 +49,18 @@ export interface MetricsData {
   details?: GrantUsageDetails;
   failed?: boolean;  // True if this was a failed request (still costs input tokens)
   error?: string;    // Error message if failed
+
+  // --- Four-channel cost tracking (additive; safe for old logs) ---
+  /** Raw per-channel token counts. Source of truth for re-deriving cost. */
+  tokens?: ChannelTokens;
+  /** Cost reported directly by the provider (OpenRouter). Authoritative when set. */
+  providerReportedCost?: number;
+  /** Cost computed from `tokens × pricing table` at write time. */
+  computedCost?: number;
+  /** `computedCost − providerReportedCost`. Non-null only when both are set. */
+  pricingDriftDelta?: number;
+  /** Hash or version stamp of the pricing table snapshot used to compute `computedCost`. */
+  pricingVersion?: string;
 }
 
 // Usage analytics types
@@ -4348,15 +4368,25 @@ export class Database {
   // Metrics methods
   
   /**
-   * Sanitize numeric fields in metrics to prevent NaN contamination
+   * Sanitize numeric fields in metrics to prevent NaN contamination.
+   *
+   * Covers both legacy aggregate fields and the four-channel `tokens` block.
+   * Optional numeric fields (`providerReportedCost`, `computedCost`,
+   * `pricingDriftDelta`) are sanitized only when present — undefined stays
+   * undefined so absence-vs-zero remains distinguishable on read.
    */
   private sanitizeMetrics(metrics: MetricsData): MetricsData {
     const safeNumber = (val: any): number => {
       const num = Number(val);
       return Number.isFinite(num) ? num : 0;
     };
-    
-    return {
+    const safeOptional = (val: any): number | undefined => {
+      if (val === undefined || val === null) return undefined;
+      const num = Number(val);
+      return Number.isFinite(num) ? num : undefined;
+    };
+
+    const sanitized: MetricsData = {
       ...metrics,
       inputTokens: safeNumber(metrics.inputTokens),
       outputTokens: safeNumber(metrics.outputTokens),
@@ -4365,6 +4395,31 @@ export class Database {
       cacheSavings: safeNumber(metrics.cacheSavings),
       responseTime: safeNumber(metrics.responseTime),
     };
+
+    if (metrics.tokens) {
+      sanitized.tokens = {
+        freshInput: safeNumber(metrics.tokens.freshInput),
+        cacheCreationInput: safeNumber(metrics.tokens.cacheCreationInput),
+        cacheCreationTtl: metrics.tokens.cacheCreationTtl,
+        cacheReadInput: safeNumber(metrics.tokens.cacheReadInput),
+        output: safeNumber(metrics.tokens.output),
+        ...(metrics.tokens.thinking !== undefined && {
+          thinking: safeNumber(metrics.tokens.thinking),
+        }),
+        ...(metrics.tokens.toolUsePrompt !== undefined && {
+          toolUsePrompt: safeNumber(metrics.tokens.toolUsePrompt),
+        }),
+      };
+    }
+
+    const reported = safeOptional(metrics.providerReportedCost);
+    if (reported !== undefined) sanitized.providerReportedCost = reported;
+    const computed = safeOptional(metrics.computedCost);
+    if (computed !== undefined) sanitized.computedCost = computed;
+    const drift = safeOptional(metrics.pricingDriftDelta);
+    if (drift !== undefined) sanitized.pricingDriftDelta = drift;
+
+    return sanitized;
   }
   
   async addMetrics(conversationId: string, conversationOwnerUserId: string, metrics: MetricsData): Promise<void> {

--- a/deprecated-claude-app/backend/src/services/anthropic.ts
+++ b/deprecated-claude-app/backend/src/services/anthropic.ts
@@ -245,12 +245,26 @@ export class AnthropicService {
           console.log(`[Anthropic API] Stream error:`, chunk.error);
         }
         
-        // Capture cache metrics from message_start
+        // Capture cache metrics AND fresh input_tokens from message_start.
+        //
+        // CRITICAL: input_tokens is canonically reported on `message_start.message.usage`.
+        // `message_delta.usage` may or may not re-emit it depending on the API
+        // version / SDK / model. We must capture it here, on the FIRST event of
+        // the stream — otherwise any message_delta that carries only
+        // `output_tokens` will, via the replace-not-merge at line 319, zero out
+        // our fresh-input count and trigger a structural undercount of the
+        // entire fresh-input portion of the bill on every Anthropic-direct call.
         if (chunk.type === 'message_start' && chunk.message?.usage) {
           const messageUsage = chunk.message.usage;
           cacheMetrics.cacheCreationInputTokens = messageUsage.cache_creation_input_tokens || 0;
           cacheMetrics.cacheReadInputTokens = messageUsage.cache_read_input_tokens || 0;
-          console.log('[Anthropic API] Cache metrics:', cacheMetrics);
+          if (typeof messageUsage.input_tokens === 'number') {
+            usage.input_tokens = messageUsage.input_tokens;
+          }
+          if (typeof messageUsage.output_tokens === 'number') {
+            usage.output_tokens = messageUsage.output_tokens;
+          }
+          console.log('[Anthropic API] Cache metrics:', cacheMetrics, 'initial usage:', usage);
         }
         
         // Handle content block start
@@ -316,7 +330,11 @@ export class AnthropicService {
             }
           }
           if (chunk.usage) {
-            usage = chunk.usage;
+            // MERGE, not replace. `message_delta.usage` typically carries only
+            // `output_tokens` (the running output total); replacing the object
+            // would clobber the `input_tokens` we captured from `message_start`
+            // and zero out the fresh-input portion of the bill.
+            usage = { ...usage, ...chunk.usage };
             console.log(`[Anthropic API] Token usage:`, usage);
           }
         } else if (chunk.type === 'message_stop') {

--- a/deprecated-claude-app/backend/src/services/bedrock.ts
+++ b/deprecated-claude-app/backend/src/services/bedrock.ts
@@ -63,7 +63,7 @@ export class BedrockService {
     messages: Message[],
     systemPrompt: string | undefined,
     settings: ModelSettings,
-    onChunk: (chunk: string, isComplete: boolean) => Promise<void>,
+    onChunk: (chunk: string, isComplete: boolean, contentBlocks?: any[], usage?: any) => Promise<void>,
     stopSequences?: string[]
   ): Promise<{ rawRequest?: any }> {
     // Demo mode - simulate streaming response
@@ -126,13 +126,58 @@ export class BedrockService {
 
       let fullContent = '';
 
+      // Usage tracking — mirrors anthropic.ts. Claude-on-Bedrock returns the
+      // same Anthropic-style event types (`message_start`, `message_delta`,
+      // `message_stop`), each carrying a `usage` block. We also opportunistically
+      // read Bedrock's own `amazon-bedrock-invocationMetrics` chunk (present at
+      // stream end on InvokeModelWithResponseStream) as a fallback / sanity check.
+      //
+      // CRITICAL: input_tokens is canonically on `message_start.message.usage`.
+      // We must capture it there because `message_delta.usage` typically only
+      // carries output_tokens; a wholesale replace would zero out fresh input.
+      // Same bug pattern that was fixed in anthropic.ts.
+      let usage: any = {};
+      const cacheMetrics = {
+        cacheCreationInputTokens: 0,
+        cacheReadInputTokens: 0,
+      };
+
       for await (const chunk of response.body) {
         if (chunk.chunk?.bytes) {
           const chunkData = JSON.parse(new TextDecoder().decode(chunk.chunk.bytes));
-          
+
+          // Capture cache + fresh input tokens from message_start (Claude 3+).
+          if (chunkData.type === 'message_start' && chunkData.message?.usage) {
+            const m = chunkData.message.usage;
+            cacheMetrics.cacheCreationInputTokens = m.cache_creation_input_tokens || 0;
+            cacheMetrics.cacheReadInputTokens = m.cache_read_input_tokens || 0;
+            if (typeof m.input_tokens === 'number') usage.input_tokens = m.input_tokens;
+            if (typeof m.output_tokens === 'number') usage.output_tokens = m.output_tokens;
+          }
+
+          // Merge (don't replace) message_delta usage so input_tokens captured
+          // from message_start survives.
+          if (chunkData.type === 'message_delta' && chunkData.usage) {
+            usage = { ...usage, ...chunkData.usage };
+          }
+
+          // Bedrock-specific invocation metrics chunk. Carries `inputTokenCount`
+          // and `outputTokenCount` directly from Bedrock's metering. Used as a
+          // fallback only — the Anthropic-style events are more granular (split
+          // cache vs fresh) so we keep those when present.
+          if (chunkData['amazon-bedrock-invocationMetrics']) {
+            const metrics = chunkData['amazon-bedrock-invocationMetrics'];
+            if (usage.input_tokens === undefined && typeof metrics.inputTokenCount === 'number') {
+              usage.input_tokens = metrics.inputTokenCount;
+            }
+            if (usage.output_tokens === undefined && typeof metrics.outputTokenCount === 'number') {
+              usage.output_tokens = metrics.outputTokenCount;
+            }
+          }
+
           // Handle different response formats based on model
           const content = this.extractContentFromChunk(modelId, chunkData);
-          
+
           if (content) {
             fullContent += content;
             chunks.push(content);
@@ -141,8 +186,23 @@ export class BedrockService {
 
           // Check if stream is complete
           if (this.isStreamComplete(modelId, chunkData)) {
-            await onChunk('', true);
-            
+            // Build actualUsage matching the shape Anthropic/OpenRouter emit.
+            // For Claude 2 / Instant (older Bedrock models) the Anthropic-style
+            // events don't exist; we still pass through whatever fell out of
+            // amazon-bedrock-invocationMetrics, else nothing — the enhanced
+            // inference layer will fall back to its chars/4 estimate.
+            const actualUsage = (usage.input_tokens !== undefined || usage.output_tokens !== undefined)
+              ? {
+                  inputTokens: usage.input_tokens || 0,
+                  outputTokens: usage.output_tokens || 0,
+                  cacheCreationInputTokens: cacheMetrics.cacheCreationInputTokens,
+                  cacheReadInputTokens: cacheMetrics.cacheReadInputTokens,
+                  cacheCreationTtl: '1h' as const,
+                }
+              : undefined;
+
+            await onChunk('', true, undefined, actualUsage);
+
             // Log the response
             const duration = Date.now() - startTime;
             await llmLogger.logResponse({
@@ -150,13 +210,14 @@ export class BedrockService {
               service: 'bedrock',
               model: bedrockModelId || modelId,
               chunks,
-              duration
+              duration,
+              tokenCount: (usage.input_tokens || 0) + (usage.output_tokens || 0),
             });
             break;
           }
         }
       }
-      
+
       return { rawRequest };
     } catch (error) {
       console.error('Bedrock streaming error:', error);

--- a/deprecated-claude-app/backend/src/services/enhanced-inference.ts
+++ b/deprecated-claude-app/backend/src/services/enhanced-inference.ts
@@ -1,4 +1,15 @@
-import { Message, Conversation, Model, ModelSettings, Participant, GrantUsageDetails, GrantTokenUsage } from '@deprecated-claude/shared';
+import {
+  Message,
+  Conversation,
+  Model,
+  ModelSettings,
+  Participant,
+  GrantUsageDetails,
+  GrantTokenUsage,
+  ChannelTokens,
+  CachePricingMultipliers,
+  DEFAULT_ANTHROPIC_CACHE_MULTIPLIERS,
+} from '@deprecated-claude/shared';
 import { ContextManager } from './context-manager.js';
 import { InferenceService } from './inference.js';
 import { ContextWindow } from './context-strategies.js';
@@ -27,12 +38,26 @@ interface CacheMetrics {
   estimatedCostSaved: number;
 }
 
+/**
+ * Per-channel cost breakdown for one provider API call.
+ *
+ * Each cache/thinking channel has its own multiplier on the base input/output price.
+ * `inputCost` and `outputCost` are kept as aggregates for display callers that still
+ * expect the flat input/output split.
+ */
 type CostBreakdown = {
-  inputCost: number;
-  outputCost: number;
+  freshInputCost: number;
+  cacheCreationCost: number;
+  cacheReadCost: number;
+  thinkingCost: number;
+  // Aggregates (for backward-compat display paths)
+  inputCost: number;   // = freshInputCost + cacheCreationCost + cacheReadCost
+  outputCost: number;  // = output·outputPrice + thinkingCost
   totalCost: number;
+  // Rates used (for grants + drift detection)
   inputPrice: number;
   outputPrice: number;
+  cacheMultipliers: Required<CachePricingMultipliers>;
 };
 
 // ============================================================================
@@ -237,7 +262,53 @@ const OUTPUT_PRICING_PER_MILLION: Record<string, number> = {
   'gpt-5.4-openrouter': 8.00,
 };
 
-const CACHE_DISCOUNT = 0.9;
+/**
+ * Map the loosely-typed `actualUsage` payload that flows from provider services
+ * onto a structured `ChannelTokens`.
+ *
+ * Recognised fields (all optional):
+ *   - `tokens: ChannelTokens` — pre-built, used directly if present
+ *   - `inputTokens` — fresh prompt tokens
+ *   - `cacheCreationInputTokens`, `cacheReadInputTokens`
+ *   - `cacheCreationTtl` (defaults to '1h' to match current cache_control usage)
+ *   - `outputTokens` (falls back to streaming chars/4 estimate if absent)
+ *   - `thinkingTokens` (Gemini thoughtsTokenCount; Anthropic includes thinking
+ *     in `outputTokens` and should not double-count by populating this)
+ *   - `toolUsePromptTokens` (Gemini)
+ */
+function tokensFromActualUsage(actualUsage: any, fallbackOutput: number = 0): ChannelTokens {
+  if (actualUsage?.tokens) return actualUsage.tokens as ChannelTokens;
+  return {
+    freshInput: actualUsage?.inputTokens ?? 0,
+    cacheCreationInput: actualUsage?.cacheCreationInputTokens ?? 0,
+    cacheCreationTtl: actualUsage?.cacheCreationTtl ?? '1h',
+    cacheReadInput: actualUsage?.cacheReadInputTokens ?? 0,
+    output: actualUsage?.outputTokens ?? fallbackOutput,
+    thinking: actualUsage?.thinkingTokens,
+    toolUsePrompt: actualUsage?.toolUsePromptTokens,
+  };
+}
+
+/**
+ * Hypothetical cost as if no caching were used — every cache-creation and cache-read
+ * token billed at the fresh input rate. Used as the baseline for the savings display
+ * metric ("you saved $X by caching"). Savings = max(baseline − actualCost, 0).
+ *
+ * Note: on cache-rebuild turns, actualCost can briefly exceed baseline (1h-TTL
+ * creation is 2× input); the clamp keeps the display sensible while the rebuilt
+ * cache amortises over subsequent reads.
+ */
+function hypotheticalNoCacheCost(
+  tokens: ChannelTokens,
+  inputPrice: number,
+  outputPrice: number,
+  thinkingMultiplier: number
+): number {
+  const allInput = tokens.freshInput + tokens.cacheCreationInput + tokens.cacheReadInput;
+  return allInput * inputPrice
+    + tokens.output * outputPrice
+    + (tokens.thinking || 0) * outputPrice * thinkingMultiplier;
+}
 
 /**
  * Validate that pricing is available for a model BEFORE making inference calls.
@@ -448,29 +519,62 @@ export class EnhancedInferenceService {
       await streamCallback(chunk, isComplete, contentBlocks);
       
       if (isComplete) {
-        // Update with actual usage from API if provided
+        // Build structured per-channel token counts. When the provider returned a
+        // usage object we trust it (after mapping); otherwise we fall back to the
+        // pre-call context-window estimate for input and the streaming chars/4
+        // estimate for output. Providers that don't return usage (currently
+        // Bedrock; openai-compatible) take the fallback path until they're wired
+        // up in subsequent commits.
+        const tokens: ChannelTokens = actualUsage
+          ? tokensFromActualUsage(actualUsage, outputTokens)
+          : {
+              freshInput: inputTokens,
+              cacheCreationInput: 0,
+              cacheReadInput: 0,
+              output: outputTokens,
+            };
+
+        // Sync the legacy scalar variables for backward-compatible downstream
+        // consumers: the CacheMetrics log entry, the context manager, and the
+        // flat fields on the onMetrics payload.
+        inputTokens = tokens.freshInput + tokens.cacheCreationInput + tokens.cacheReadInput;
+        outputTokens = tokens.output + (tokens.thinking || 0);
+        cachedTokens = tokens.cacheReadInput > 0 ? tokens.cacheReadInput : tokens.cacheCreationInput;
+        cacheHit = tokens.cacheReadInput > 0;
+
         if (actualUsage) {
-          // Provider semantics (both Anthropic and OpenRouter now match):
-          // - inputTokens = fresh (non-cached) tokens only
-          // - cacheCreationInputTokens = tokens written to cache
-          // - cacheReadInputTokens = tokens read from cache
-          // Total prompt = fresh + cache_creation + cache_read
-          const freshTokens = actualUsage.inputTokens ?? 0; // Defensive default to prevent NaN
-          const cacheCreation = actualUsage.cacheCreationInputTokens || 0;
-          const cacheRead = actualUsage.cacheReadInputTokens || 0;
-          
-          inputTokens = freshTokens + cacheCreation + cacheRead; // TOTAL input
-          outputTokens = actualUsage.outputTokens ?? 0; // Defensive default
-          // Cache size: creation OR read (whichever is non-zero shows current cache size)
-          cachedTokens = cacheRead > 0 ? cacheRead : cacheCreation;
-          cacheHit = cacheRead > 0;
-          
-          Logger.cache(`[EnhancedInference] ✅ Actual usage: fresh=${freshTokens}, cacheCreate=${cacheCreation}, cacheRead=${cacheRead}, output=${outputTokens}`);
+          Logger.cache(
+            `[EnhancedInference] ✅ Actual usage: fresh=${tokens.freshInput}, ` +
+            `cacheCreate=${tokens.cacheCreationInput} (ttl=${tokens.cacheCreationTtl}), ` +
+            `cacheRead=${tokens.cacheReadInput}, output=${tokens.output}` +
+            `${tokens.thinking ? `, thinking=${tokens.thinking}` : ''}`
+          );
           Logger.cache(`[EnhancedInference]   Total input=${inputTokens}, cache size=${cachedTokens}`);
         }
-        
-        // Log metrics
-        const estimatedSaved = await this.calculateCostSaved(model, cachedTokens);
+
+        // Compute cost per-channel using the four-channel multiplier model.
+        const breakdown = await this.calculateCostBreakdown(model, tokens);
+
+        // Provider-reported cost (currently OpenRouter via `usage.cost`) is
+        // authoritative when present. We still compute from tokens so we can
+        // surface pricing-table drift as a continuous regression signal.
+        const providerReportedCost: number | undefined = actualUsage?.providerReportedCost;
+        const computedCost = breakdown.totalCost;
+        const cost = providerReportedCost ?? computedCost;
+        const pricingDriftDelta = providerReportedCost !== undefined
+          ? computedCost - providerReportedCost
+          : undefined;
+
+        // Savings is a display-only derived metric: hypothetical cost if NO
+        // caching were used, minus actual cost. Clamped at 0 for display.
+        const baseline = hypotheticalNoCacheCost(
+          tokens,
+          breakdown.inputPrice,
+          breakdown.outputPrice,
+          breakdown.cacheMultipliers.thinking
+        );
+        const cacheSavings = Math.max(baseline - cost, 0);
+
         const metric: CacheMetrics = {
           conversationId: conversation.id,
           participantId: participant?.id,
@@ -481,18 +585,18 @@ export class EnhancedInferenceService {
           inputTokens,
           cachedTokens,
           outputTokens,
-          estimatedCostSaved: estimatedSaved,
+          estimatedCostSaved: cacheSavings,
         };
-        
+
         this.metricsLog.push(metric);
-        
+
         // Note: Cache hit/miss details are logged by the provider service (Anthropic/OpenRouter)
         // which has access to the actual API response metrics. We just track expected vs actual
         // in our context manager statistics below.
-        
+
         // Update context manager statistics
         this.contextManager.updateAfterInference(
-          conversation.id, 
+          conversation.id,
           {
             cacheHit,
             tokensUsed: inputTokens + outputTokens,
@@ -500,25 +604,39 @@ export class EnhancedInferenceService {
           },
           participant?.id
         );
-        
+
         // Call metrics callback if provided
         if (onMetrics) {
           const endTime = Date.now();
-          const breakdown = await this.calculateCostBreakdown(model, inputTokens, outputTokens);
-          const savings = await this.calculateCostSaved(model, cachedTokens);
+
+          if (pricingDriftDelta !== undefined && Math.abs(pricingDriftDelta) > 0.0001) {
+            const sign = pricingDriftDelta > 0 ? 'over' : 'under';
+            Logger.cache(
+              `[EnhancedInference] ⚖️  Pricing drift on ${model.displayName}: ` +
+              `computed=$${computedCost.toFixed(6)} provider=$${providerReportedCost!.toFixed(6)} ` +
+              `(table ${sign}estimates by $${Math.abs(pricingDriftDelta).toFixed(6)})`
+            );
+          }
+
           await onMetrics({
+            // --- Legacy flat fields (unchanged contract for existing consumers) ---
             inputTokens,
             outputTokens,
             cachedTokens,
-            cost: Math.max(breakdown.totalCost - savings, 0),
-            cacheSavings: savings,
+            cost,
+            cacheSavings,
             model: model.id,
             timestamp: new Date().toISOString(),
             responseTime: endTime - startTime,
-            details: this.buildUsageDetails(breakdown, inputTokens, outputTokens, cachedTokens),
-            // Pass through failure info if present (for failed request tracking)
+            details: this.buildUsageDetails(breakdown, tokens),
+            // --- New structured fields ---
+            tokens,
+            providerReportedCost,
+            computedCost,
+            pricingDriftDelta,
+            // --- Failure passthrough (unchanged) ---
             ...(actualUsage?.failed && { failed: true }),
-            ...(actualUsage?.error && { error: actualUsage.error })
+            ...(actualUsage?.error && { error: actualUsage.error }),
           });
         }
       }
@@ -641,45 +759,151 @@ export class EnhancedInferenceService {
     return Math.ceil(text.length / 4);
   }
   
-  private async calculateCostSaved(model: Model, cachedTokens: number): Promise<number> {
-    const pricePerToken = await this.getInputPricePerToken(model);
-    return cachedTokens * pricePerToken * CACHE_DISCOUNT;
-  }
-
-  private async calculateCostBreakdown(model: Model, inputTokens: number, outputTokens: number): Promise<CostBreakdown> {
+  /**
+   * Four-channel cost calculation.
+   *
+   * Each channel is billed at the model's base input/output rate times the
+   * channel's multiplier (default Anthropic-published values, overridable per
+   * model via `ModelCost.cachePricing`).
+   *
+   *   freshInput        :  inputPrice  × 1.0
+   *   cacheCreationInput:  inputPrice  × (1.25 if 5m TTL, 2.0 if 1h TTL)
+   *   cacheReadInput    :  inputPrice  × 0.1
+   *   output            :  outputPrice × 1.0
+   *   thinking          :  outputPrice × 1.0  (separate channel where provider reports it)
+   *
+   * Replaces the previous flat `inputCost + outputCost − 90%·savings` formula,
+   * which structurally undercounted cache-creation by ~20× on 1h-TTL writes
+   * (charged at ~10% when reality is 200%).
+   */
+  private async calculateCostBreakdown(model: Model, tokens: ChannelTokens): Promise<CostBreakdown> {
     const inputPrice = await this.getInputPricePerToken(model);
     const outputPrice = await this.getOutputPricePerToken(model);
-    const inputCost = inputTokens * inputPrice;
-    const outputCost = outputTokens * outputPrice;
+    const mults = await this.getCacheMultipliers(model);
+
+    const ttl = tokens.cacheCreationTtl ?? '1h';
+    const creationMult = ttl === '5m' ? mults.creation5m : mults.creation1h;
+
+    const freshInputCost = tokens.freshInput * inputPrice;
+    const cacheCreationCost = tokens.cacheCreationInput * inputPrice * creationMult;
+    const cacheReadCost = tokens.cacheReadInput * inputPrice * mults.read;
+    const baseOutputCost = tokens.output * outputPrice;
+    const thinkingCost = (tokens.thinking || 0) * outputPrice * mults.thinking;
+
+    const inputCost = freshInputCost + cacheCreationCost + cacheReadCost;
+    const outputCost = baseOutputCost + thinkingCost;
+    const totalCost = inputCost + outputCost;
 
     return {
+      freshInputCost,
+      cacheCreationCost,
+      cacheReadCost,
+      thinkingCost,
       inputCost,
       outputCost,
-      totalCost: inputCost + outputCost,
+      totalCost,
       inputPrice,
-      outputPrice
+      outputPrice,
+      cacheMultipliers: mults,
     };
   }
 
+  /**
+   * Resolve cache pricing multipliers for a model.
+   *
+   * Order: (1) admin-configured override in `ModelCost.cachePricing`, (2) default
+   * Anthropic-published multipliers. The defaults are correct for every
+   * Anthropic-family model regardless of access path (direct, Bedrock, OpenRouter);
+   * non-Anthropic providers with different cache pricing should be overridden in
+   * admin config.
+   */
+  private async getCacheMultipliers(model: Model): Promise<Required<CachePricingMultipliers>> {
+    try {
+      const configLoader = ConfigLoader.getInstance();
+      const config = await configLoader.loadConfig();
+      const profiles = config.providers[model.provider as keyof typeof config.providers];
+      if (profiles && profiles.length > 0) {
+        for (const profile of profiles) {
+          if (profile.modelCosts) {
+            const modelCost = profile.modelCosts.find(mc =>
+              mc.modelId === model.providerModelId || mc.modelId === model.id
+            );
+            if (modelCost?.cachePricing) {
+              const merged = { ...DEFAULT_ANTHROPIC_CACHE_MULTIPLIERS, ...modelCost.cachePricing };
+              return {
+                ...merged,
+                thinking: merged.thinking ?? DEFAULT_ANTHROPIC_CACHE_MULTIPLIERS.thinking,
+              };
+            }
+          }
+        }
+      }
+    } catch (error) {
+      console.warn('[Pricing] Error loading cache multipliers from config:', error);
+    }
+    return DEFAULT_ANTHROPIC_CACHE_MULTIPLIERS;
+  }
+
+  /**
+   * Produce a per-channel `GrantUsageDetails` for the grant ledger and usage
+   * aggregation. Each entry records (price-per-token, token-count, credits) for
+   * one channel; `credits` reflects the actual billed amount for that channel.
+   *
+   * Legacy `cached_input` is kept populated for downstream consumers (database
+   * usage-summary at `database/index.ts:1848` reads `details.cached_input?.tokens`).
+   * Its `price` is the effective per-token rate weighted across creation and read.
+   */
   private buildUsageDetails(
     breakdown: CostBreakdown,
-    inputTokens: number,
-    outputTokens: number,
-    cachedTokens: number
+    tokens: ChannelTokens
   ): GrantUsageDetails {
     const details: GrantUsageDetails = {};
 
-    if (inputTokens > 0) {
-      details.input = this.createTokenUsage(breakdown.inputPrice, inputTokens);
+    if (tokens.freshInput > 0) {
+      details.input = this.createTokenUsage(breakdown.inputPrice, tokens.freshInput, breakdown.freshInputCost);
     }
 
-    if (outputTokens > 0) {
-      details.output = this.createTokenUsage(breakdown.outputPrice, outputTokens);
+    if (tokens.cacheCreationInput > 0) {
+      const ttl = tokens.cacheCreationTtl ?? '1h';
+      const mult = ttl === '5m' ? breakdown.cacheMultipliers.creation5m : breakdown.cacheMultipliers.creation1h;
+      details.cache_creation_input = this.createTokenUsage(
+        breakdown.inputPrice * mult,
+        tokens.cacheCreationInput,
+        breakdown.cacheCreationCost
+      );
     }
 
-    if (cachedTokens > 0) {
-      const cachedPrice = -breakdown.inputPrice * CACHE_DISCOUNT;
-      details.cached_input = this.createTokenUsage(cachedPrice, cachedTokens);
+    if (tokens.cacheReadInput > 0) {
+      details.cache_read_input = this.createTokenUsage(
+        breakdown.inputPrice * breakdown.cacheMultipliers.read,
+        tokens.cacheReadInput,
+        breakdown.cacheReadCost
+      );
+    }
+
+    if (tokens.output > 0) {
+      details.output = this.createTokenUsage(
+        breakdown.outputPrice,
+        tokens.output,
+        tokens.output * breakdown.outputPrice
+      );
+    }
+
+    if (tokens.thinking && tokens.thinking > 0) {
+      details.reasoning_output = this.createTokenUsage(
+        breakdown.outputPrice * breakdown.cacheMultipliers.thinking,
+        tokens.thinking,
+        breakdown.thinkingCost
+      );
+    }
+
+    // Legacy aggregated `cached_input` — downstream usage summary still reads
+    // `details.cached_input?.tokens` (database/index.ts:1848).
+    const totalCached = tokens.cacheCreationInput + tokens.cacheReadInput;
+    if (totalCached > 0) {
+      const totalCachedCost = breakdown.cacheCreationCost + breakdown.cacheReadCost;
+      const effectivePrice = totalCachedCost / totalCached;
+      details.cached_input = this.createTokenUsage(effectivePrice, totalCached, totalCachedCost);
     }
 
     return details;

--- a/deprecated-claude-app/backend/src/services/gemini.ts
+++ b/deprecated-claude-app/backend/src/services/gemini.ts
@@ -51,6 +51,18 @@ interface GeminiResponse {
     promptTokenCount: number;
     candidatesTokenCount: number;
     totalTokenCount: number;
+    // Thinking/reasoning output tokens (Gemini 2.5+ thinking mode). Billed at
+    // the output rate; reported as a SEPARATE count from candidatesTokenCount
+    // per Google's spec (not a subset — total billable output is sum of both).
+    thoughtsTokenCount?: number;
+    // Cache-read input tokens (Gemini context caching). Subset of
+    // promptTokenCount — subtract to get the fresh-input portion. Gemini's
+    // cache pricing is ~25% of input (vs Anthropic's 10%); admin config
+    // should override `cachePricing.read` for accurate billing on Gemini.
+    cachedContentTokenCount?: number;
+    // Tool-use prompt scaffolding tokens. Subset of promptTokenCount; tracked
+    // for visibility but billed at the same input rate as fresh.
+    toolUsePromptTokenCount?: number;
   };
 }
 
@@ -73,6 +85,18 @@ interface GeminiStreamChunk {
     promptTokenCount: number;
     candidatesTokenCount: number;
     totalTokenCount: number;
+    // Thinking/reasoning output tokens (Gemini 2.5+ thinking mode). Billed at
+    // the output rate; reported as a SEPARATE count from candidatesTokenCount
+    // per Google's spec (not a subset — total billable output is sum of both).
+    thoughtsTokenCount?: number;
+    // Cache-read input tokens (Gemini context caching). Subset of
+    // promptTokenCount — subtract to get the fresh-input portion. Gemini's
+    // cache pricing is ~25% of input (vs Anthropic's 10%); admin config
+    // should override `cachePricing.read` for accurate billing on Gemini.
+    cachedContentTokenCount?: number;
+    // Tool-use prompt scaffolding tokens. Subset of promptTokenCount; tracked
+    // for visibility but billed at the same input rate as fresh.
+    toolUsePromptTokenCount?: number;
   };
 }
 
@@ -336,11 +360,31 @@ export class GeminiService {
                 }
               }
               
-              // Extract usage (with defensive defaults to prevent NaN)
+              // Extract usage across all billable channels Gemini reports.
+              //
+              // Channel semantics (per Google's spec):
+              //   promptTokenCount        = total input (includes cached + tool-use)
+              //   cachedContentTokenCount = subset of prompt read from cache
+              //   toolUsePromptTokenCount = subset of prompt used by tool scaffolding
+              //   candidatesTokenCount    = visible output (does NOT include thinking)
+              //   thoughtsTokenCount      = thinking output (separate, both billed at output rate)
+              //
+              // We pass fresh = promptTokenCount − cached so the four-channel
+              // cost model doesn't double-charge cached tokens. cacheRead is the
+              // cached portion; cacheCreation is 0 because Gemini creates caches
+              // out-of-band via a separate API (CachedContent.create), not as
+              // part of generation requests.
               if (chunk.usageMetadata) {
+                const meta = chunk.usageMetadata;
+                const cached = meta.cachedContentTokenCount ?? 0;
+                const promptTotal = meta.promptTokenCount ?? 0;
                 usage = {
-                  inputTokens: chunk.usageMetadata.promptTokenCount ?? 0,
-                  outputTokens: chunk.usageMetadata.candidatesTokenCount ?? 0,
+                  inputTokens: Math.max(promptTotal - cached, 0),
+                  outputTokens: meta.candidatesTokenCount ?? 0,
+                  cacheCreationInputTokens: 0,
+                  cacheReadInputTokens: cached,
+                  ...(meta.thoughtsTokenCount ? { thinkingTokens: meta.thoughtsTokenCount } : {}),
+                  ...(meta.toolUsePromptTokenCount ? { toolUsePromptTokens: meta.toolUsePromptTokenCount } : {}),
                 };
               }
             } catch (parseError) {
@@ -569,10 +613,21 @@ export class GeminiService {
     return {
       content,
       contentBlocks,
-      usage: data.usageMetadata ? {
-        inputTokens: data.usageMetadata.promptTokenCount,
-        outputTokens: data.usageMetadata.candidatesTokenCount,
-      } : undefined,
+      // Mirror the per-channel extraction the streaming path now does.
+      // See the streaming branch above for channel semantics.
+      usage: data.usageMetadata ? (() => {
+        const meta = data.usageMetadata!;
+        const cached = meta.cachedContentTokenCount ?? 0;
+        const promptTotal = meta.promptTokenCount ?? 0;
+        return {
+          inputTokens: Math.max(promptTotal - cached, 0),
+          outputTokens: meta.candidatesTokenCount ?? 0,
+          cacheCreationInputTokens: 0,
+          cacheReadInputTokens: cached,
+          ...(meta.thoughtsTokenCount ? { thinkingTokens: meta.thoughtsTokenCount } : {}),
+          ...(meta.toolUsePromptTokenCount ? { toolUsePromptTokens: meta.toolUsePromptTokenCount } : {}),
+        };
+      })() : undefined,
     };
   }
 

--- a/deprecated-claude-app/backend/src/services/openrouter.ts
+++ b/deprecated-claude-app/backend/src/services/openrouter.ts
@@ -36,6 +36,24 @@ interface OpenRouterResponse {
     // Anthropic cache fields (via OpenRouter)
     cache_creation_input_tokens?: number;
     cache_read_input_tokens?: number;
+    // OpenRouter ground-truth cost — present when the request includes
+    // `usage: { include: true }` (which this service always sends).
+    // Authoritative; bypasses the pricing-table math when set.
+    cost?: number;
+    cost_details?: {
+      upstream_inference_cost?: number;
+      [key: string]: any;
+    };
+    // Reasoning/thinking output breakdown (some models). Billed inside
+    // `completion_tokens`, surfaced separately for accurate token attribution.
+    completion_tokens_details?: {
+      reasoning_tokens?: number;
+      [key: string]: any;
+    };
+    prompt_tokens_details?: {
+      cached_tokens?: number;
+      [key: string]: any;
+    };
   };
 }
 
@@ -157,13 +175,18 @@ export class OpenRouterService {
       // Complete the stream
       // NOTE: inputTokens = fresh only (non-cached), to match Anthropic semantics
       // enhanced-inference.ts will add cacheRead to get total
-      const actualUsage = {
+      const actualUsage: any = {
         inputTokens: freshInputTokens,
         outputTokens: completionTokens,
         cacheCreationInputTokens: 0, // OpenRouter doesn't distinguish
         cacheReadInputTokens: cachedTokens
       };
-      
+
+      // OpenRouter ground-truth cost (when present). Authoritative for billing.
+      if (typeof usage.cost === 'number') {
+        actualUsage.providerReportedCost = usage.cost;
+      }
+
       await onChunk('', true, undefined, actualUsage);
       
       return {
@@ -307,11 +330,17 @@ export class OpenRouterService {
       let totalTokens = 0;
       let promptTokens = 0;
       let completionTokens = 0;
+      let reasoningTokens = 0;
+      // OpenRouter ground-truth cost. Set when the final SSE chunk carries
+      // `usage.cost` (we always request `usage: { include: true }`). Authoritative
+      // when set; passed through `actualUsage.providerReportedCost` so the cost
+      // tracker short-circuits the pricing-table math and surfaces drift.
+      let reportedCost: number | undefined;
       let cacheMetrics = {
         cacheCreationInputTokens: 0,
         cacheReadInputTokens: 0
       };
-      
+
       // Track reasoning/thinking content blocks
       const contentBlocks: any[] = [];
       let reasoningContent = '';
@@ -333,21 +362,44 @@ export class OpenRouterService {
               // OpenRouter's prompt_tokens is TOTAL (includes cached)
               // Report fresh tokens only, to match Anthropic semantics
               const freshInputTokens = promptTokens - cacheMetrics.cacheReadInputTokens;
-              
-              const actualUsage = {
+
+              const actualUsage: any = {
                 inputTokens: freshInputTokens,
                 outputTokens: completionTokens,
                 cacheCreationInputTokens: cacheMetrics.cacheCreationInputTokens,
-                cacheReadInputTokens: cacheMetrics.cacheReadInputTokens
+                cacheReadInputTokens: cacheMetrics.cacheReadInputTokens,
               };
-              
+
+              // Ground-truth cost from OpenRouter (when present). Marks this
+              // record as authoritative — enhanced-inference will use it as
+              // `cost` and log the delta vs. its table-computed value as
+              // `pricingDriftDelta` for table-drift detection.
+              if (reportedCost !== undefined) {
+                actualUsage.providerReportedCost = reportedCost;
+                Logger.cache(`[OpenRouter] 💰 Reported cost: $${reportedCost.toFixed(6)}`);
+              }
+
+              // OpenRouter's `reasoning_tokens` are a SUBSET of `completion_tokens`,
+              // not a separate count. To let the four-channel model apply a distinct
+              // `thinking` multiplier (configurable per model) without double-counting,
+              // we split:
+              //   outputTokens   = completion_tokens − reasoning_tokens   (non-thinking)
+              //   thinkingTokens = reasoning_tokens                        (thinking)
+              // With the default 1.0× thinking multiplier this billing is identical
+              // to the pre-split behaviour; admin config can override per model for
+              // premium reasoning rates.
+              if (reasoningTokens > 0 && reasoningTokens <= completionTokens) {
+                actualUsage.outputTokens = completionTokens - reasoningTokens;
+                actualUsage.thinkingTokens = reasoningTokens;
+              }
+
               // Include content blocks (reasoning) in final response
               const finalContentBlocks = contentBlocks.length > 0 ? contentBlocks : undefined;
-              
+
               if (hasReasoningStarted) {
                 console.log(`[OpenRouter] 🧠 Reasoning complete: ${reasoningContent.length} chars`);
               }
-              
+
               await onChunk('', true, finalContentBlocks, actualUsage);
               break;
             }
@@ -508,7 +560,24 @@ export class OpenRouterService {
                 totalTokens = parsed.usage.total_tokens;
                 promptTokens = parsed.usage.prompt_tokens || 0;
                 completionTokens = parsed.usage.completion_tokens || 0;
-                
+
+                // OpenRouter ground-truth cost. Sent in the final SSE chunk
+                // when the request includes `usage: { include: true }` (this
+                // service always sends it). Authoritative — skips the pricing
+                // table downstream. We still want to log it even if the chunk
+                // is parsed multiple times; the value is monotonic for one call.
+                if (typeof parsed.usage.cost === 'number') {
+                  reportedCost = parsed.usage.cost;
+                }
+
+                // Reasoning tokens are billed inside `completion_tokens` already.
+                // Capturing the split so the four-channel cost model can apply
+                // a separate `thinking` multiplier if the model's pricing differs
+                // (e.g., overridden in admin config).
+                if (parsed.usage.completion_tokens_details?.reasoning_tokens !== undefined) {
+                  reasoningTokens = parsed.usage.completion_tokens_details.reasoning_tokens;
+                }
+
                 // OpenRouter format: cache info in prompt_tokens_details.cached_tokens
                 if (parsed.usage.prompt_tokens_details?.cached_tokens) {
                   // OpenRouter doesn't distinguish creation vs read, just reports cached
@@ -517,7 +586,7 @@ export class OpenRouterService {
                 } else {
                   Logger.cache(`[OpenRouter] ❌ No cache hit (cached_tokens: ${parsed.usage.prompt_tokens_details?.cached_tokens || 0})`);
                 }
-                
+
                 // Also check for native Anthropic format (fallback)
                 if (parsed.usage.cache_creation_input_tokens !== undefined) {
                   cacheMetrics.cacheCreationInputTokens = parsed.usage.cache_creation_input_tokens;

--- a/deprecated-claude-app/shared/src/index.ts
+++ b/deprecated-claude-app/shared/src/index.ts
@@ -3,6 +3,7 @@ export * from './import-types.js';
 export * from './api-types.js';
 export * from './grants.js';
 export * from './sharing.js';
+export * from './usage.js';
 
 // Utility functions for handling conversation branches
 export function getActiveBranch(message: import('./types.js').Message): import('./types.js').MessageBranch | undefined {

--- a/deprecated-claude-app/shared/src/usage.ts
+++ b/deprecated-claude-app/shared/src/usage.ts
@@ -1,0 +1,126 @@
+/**
+ * Per-channel token accounting for a single provider API call.
+ *
+ * Every billable channel that a provider exposes gets its own field. Channels are
+ * priced at different multiples of the model's base input/output rate, so collapsing
+ * them into a single `inputTokens` field (and applying a flat 90% "savings" discount)
+ * structurally undercounts cache-creation and overcounts cache-read parity.
+ *
+ * The shape is provider-agnostic: each provider's extraction layer maps its native
+ * response fields onto this schema, leaving unknown channels at 0.
+ */
+export interface ChannelTokens {
+  /** Fresh (non-cached, non-thinking) prompt tokens. Billed at the model's base input rate. */
+  freshInput: number;
+  /** Prompt tokens written to cache this call. Billed at base input × creation multiplier (see `cacheCreationTtl`). */
+  cacheCreationInput: number;
+  /** TTL of the cache writes in this call. Determines which creation multiplier applies. Defaults to '1h' (matches current cache_control behavior). */
+  cacheCreationTtl?: '5m' | '1h';
+  /** Prompt tokens read from cache this call. Billed at base input × read multiplier (typically 0.1×). */
+  cacheReadInput: number;
+  /** Completion tokens (everything the model emits that isn't separately broken out). Billed at base output rate. */
+  output: number;
+  /**
+   * Extended-thinking / reasoning tokens, when the provider reports them as a separate
+   * channel from regular output (Gemini `thoughtsTokenCount`; OpenRouter
+   * `completion_tokens_details.reasoning_tokens`). When the provider folds reasoning
+   * into `output_tokens` (Anthropic), leave this at 0.
+   * Billed at base output × thinking multiplier (default 1.0× — same as output).
+   */
+  thinking?: number;
+  /** Gemini-specific: tokens spent on tool-use prompt scaffolding. Billed as input. */
+  toolUsePrompt?: number;
+}
+
+/**
+ * Per-model multipliers applied to the base input/output prices for the non-fresh-input
+ * and non-output channels. The set of channels here matches the optional fields in
+ * `ChannelTokens` that aren't priced at the base rate.
+ *
+ * Anthropic's published values are the defaults; other providers' overrides can be
+ * configured per-model in `production-models.json` when their cache pricing differs.
+ */
+export interface CachePricingMultipliers {
+  /** Multiplier on base input price for cache-read tokens. */
+  read: number;
+  /** Multiplier on base input price for cache-creation tokens with 5-minute TTL. */
+  creation5m: number;
+  /** Multiplier on base input price for cache-creation tokens with 1-hour TTL. */
+  creation1h: number;
+  /** Multiplier on base output price for thinking/reasoning tokens. Optional — defaults to 1.0×. */
+  thinking?: number;
+}
+
+/**
+ * Anthropic's published prompt-cache pricing multipliers, applied to the base input price.
+ *
+ * Reference: https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching#pricing
+ *  - Cache read:                        0.1× input  (90% discount)
+ *  - Cache creation, 5-minute TTL:      1.25× input (25% premium)
+ *  - Cache creation, 1-hour TTL:        2.0× input  (100% premium)
+ *
+ * Used as the default when a model's `ModelCost.cachePricing` is not configured.
+ */
+export const DEFAULT_ANTHROPIC_CACHE_MULTIPLIERS: Required<CachePricingMultipliers> = {
+  read: 0.1,
+  creation5m: 1.25,
+  creation1h: 2.0,
+  thinking: 1.0,
+};
+
+/**
+ * One `UsageRecord` is emitted per provider API call — not per user message.
+ *
+ * Branches (parallel sampling), retried streams, tool-use rounds, and aborted streams
+ * that produced partial output each emit their own record. Aggregation is a flat sum
+ * over records; nothing is deduplicated upstream.
+ *
+ * The `tokens` block is the source of truth. `computedCost` is a cache of the
+ * tokens-times-pricing-table math, allowed to lag if the pricing table changes —
+ * the raw tokens let us re-derive correct historic costs after pricing fixes.
+ *
+ * When a provider returns ground-truth cost directly (OpenRouter via `usage.cost`),
+ * it lands in `providerReportedCost` and overrides `computedCost` for aggregation
+ * purposes. The two values are kept side-by-side so that `pricingDriftDelta` can
+ * surface pricing-table drift as a continuous regression signal.
+ */
+export interface UsageRecord {
+  /** Stable id for dedup across retries and replay. */
+  id: string;
+  /** ISO-8601 timestamp of when the API call completed (or aborted). */
+  timestamp: string;
+  conversationId: string;
+  /** The message this call produced (or attempted to produce). */
+  messageId: string;
+  /** Branch index within the message for parallel-sampling generations. 0 for single-sample. */
+  branchIndex: number;
+  /** Which participant the call was made for. Optional for legacy events. */
+  participantId?: string;
+  /** Provider tag — 'anthropic' | 'bedrock' | 'openrouter' | 'gemini' | 'openai-compatible'. */
+  provider: string;
+  /** Display name or providerModelId — used for per-model rollup in the UI. */
+  model: string;
+  /** Raw per-channel token counts. Source of truth. */
+  tokens: ChannelTokens;
+  /**
+   * Cost reported directly by the provider's response (currently OpenRouter only,
+   * via `usage.cost` when `usage: { include: true }` is requested). Authoritative
+   * when present.
+   */
+  providerReportedCost?: number;
+  /**
+   * Cost we computed from `tokens` × pricing table at the time of write. Cached for
+   * fast display; can be re-derived from `tokens` if the pricing table is corrected.
+   */
+  computedCost?: number;
+  /**
+   * `computedCost − providerReportedCost`. Non-null only when both are set. Positive
+   * means our table overestimates; negative means we underestimate. A persistent
+   * non-zero drift is a signal that the pricing table is stale.
+   */
+  pricingDriftDelta?: number;
+  /** Hash or version stamp of the pricing table snapshot used to compute `computedCost`. */
+  pricingVersion?: string;
+  /** Whether the API call completed cleanly. Partial output from aborted/errored streams is still billed by the provider. */
+  status: 'complete' | 'aborted' | 'errored';
+}


### PR DESCRIPTION
## Why

Per-conversation cost totals consistently under-report vs. the actual provider
bill. Root cause is structural, not a single calculation bug — see the
architectural audit / commit B body for the full breakdown. Summary of the
worst offender: every Anthropic-family `cache_creation` token was charged at
~10% effective rate when reality on 1h-TTL writes is 200%, a ~20× undercount
on the creation portion (~28%+ on rebuild turns, more on creation-only turns).

## What

Seven independently-reviewable commits on this branch. Each is gated to its
own concern; the heavy lift is commit B.

```
chore(cost-tracker): add ChannelTokens + UsageRecord types as foundation
fix(cost-tracker): four-channel cost computation; provider-reported override   ⭐
fix(cost-tracker): pass OpenRouter usage.cost through as ground-truth cost
fix(cost-tracker): preserve Anthropic input_tokens across message_delta merge
fix(cost-tracker): extract Gemini thinking + cache + tool-use channels
fix(cost-tracker): extract Bedrock usage from streaming response
fix(cost-tracker): persist four-channel tokens + drift fields in JSONL log
```

Each commit message contains its own findings + worked example. The big-picture
summary:

### Four-channel pricing model

Replaces `inputCost + outputCost − 90%·cachedTokens·inputPrice` with explicit
per-channel rates that match published provider pricing:

|  Channel | Multiplier on base rate |
|----------|------------------------|
| freshInput | `inputPrice × 1.0` |
| cacheCreationInput (5m TTL) | `inputPrice × 1.25` |
| cacheCreationInput (1h TTL) | `inputPrice × 2.0` |
| cacheReadInput | `inputPrice × 0.1` |
| output | `outputPrice × 1.0` |
| thinking | `outputPrice × 1.0` (default; per-model overridable) |

Defaults are Anthropic's published values — correct for all Anthropic-family
models regardless of access path (direct, Bedrock, OpenRouter). Other providers
override via `ModelCost.cachePricing` in admin config (e.g. Gemini's ~25% cache
read multiplier).

### Provider-reported cost short-circuit

OpenRouter returns `usage.cost` in every streamed response when the request
includes `usage: { include: true }` (which this service has always done). That
value was being captured in a log line and dropped everywhere else. Now it's
threaded through as `actualUsage.providerReportedCost`; when present, it is
authoritative — `computedCost` is logged side-by-side so any drift surfaces as
`pricingDriftDelta`. For OpenRouter conversations this bypasses the pricing
table entirely.

### Provider extraction fixes

- **Anthropic-direct**: `message_start.usage.input_tokens` was never being
  captured (only the cache fields were); `message_delta.usage` was REPLACING
  rather than merging, zeroing the fresh-input count. Both fixed.
- **Bedrock**: was extracting *nothing* — 2-arg `onChunk` signature, no usage
  parsing. Now reads the same Anthropic-style events plus
  `amazon-bedrock-invocationMetrics` as fallback.
- **Gemini**: was reading 2 of 5 billable channels. Now reads thinking
  (`thoughtsTokenCount`), cache (`cachedContentTokenCount`), and tool-use
  prompts.

### Schema (additive, backward-compatible)

`MetricsData` (persisted as `metrics_added` events in the JSONL log) gains
optional fields: `tokens` (raw per-channel counts), `providerReportedCost`,
`computedCost`, `pricingDriftDelta`, `pricingVersion`. Legacy events without
these fields replay unchanged.

Types live in `@deprecated-claude/shared` (`shared/src/usage.ts`).

## Worked example (commit B body has more)

Claude Opus 4.7 ($5/M in, $25/M out); one cache-rebuild turn with 500 fresh +
10K cache_creation_1h + 50K cache_read + 2K output:

```
Old: $0.0025 fresh + $0.05 in_pool − $0.225 savings + $0.05 out = $0.1275
New: $0.0025 fresh + $0.100 creation + $0.025 read + $0.05 out  = $0.1775
Δ:   −28% on this turn; up to −62% on creation-only turns.
```

## Test plan

- [ ] Backend typechecks cleanly (verified locally; only pre-existing
      `express-rate-limit` import error from #94 remains, unrelated)
- [ ] Shared package rebuilds with `usage.d.ts` artefacts generated
- [ ] Send a single message on each provider and confirm the new
      `Logger.cache` lines fire with per-channel breakdown:
      - Anthropic-direct: `fresh=`, `cacheCreate=`, `cacheRead=`, `output=`
      - OpenRouter: `💰 Reported cost: $X`
      - Bedrock: usage extraction reaches the cost path (vs. chars/4 estimate)
      - Gemini: `thinking=` appears when a thinking model is used
- [ ] Confirm `pricingDriftDelta` logs fire on OpenRouter calls where the
      table-computed cost differs from the reported one (this is the
      regression signal we now have)
- [ ] Cache-heavy conversation: per-conversation cost total visibly higher
      than before the change (the bug is fixed → numbers go UP)
- [ ] Existing conversation reload: legacy `metrics_added` events from the
      JSONL log replay without error (additive schema verified)

## Known follow-ups (not in this PR)

- Drop `branchIndex === 0` gate in `handler.ts:586` — parallel sampling
  branches still record only branch 0, undercounting by sampling count
- Record partial usage on aborted streams (currently `enhanced-inference.ts:441`
  throws before the `onMetrics` block)
- Gemini-specific `cachePricing` multipliers in admin config / production-models.json
- Frontend display of `pricingDriftDelta` / per-channel breakdown
- `api-key-manager.ts:206-210` has its own flat-cost calc using
  `providerCost.inputTokensPerMillion` — separate from the metrics path
  fixed here; would benefit from the same four-channel treatment

🤖 Generated with [Claude Code](https://claude.com/claude-code)