### PR TITLE
fix(ui): two follow-ups to #99 and #101 from post-merge testing

### DIFF
--- a/deprecated-claude-app/frontend/src/views/ConversationView.vue
+++ b/deprecated-claude-app/frontend/src/views/ConversationView.vue
@@ -232,11 +232,11 @@
           </v-list>
           
           <!-- Shared with me section -->
-          <v-list v-if="sharedConversations.length > 0" density="compact" nav class="mt-2">
+          <v-list v-if="filteredSharedConversations.length > 0" density="compact" nav class="mt-2">
             <v-list-subheader>Shared with me</v-list-subheader>
-            
+
             <v-list-item
-              v-for="share in sharedConversations"
+              v-for="share in filteredSharedConversations"
               :key="share.id"
               :to="`/conversation/${share.conversationId}`"
               class="conversation-list-item"
@@ -262,8 +262,8 @@
               <template v-slot:subtitle>
                 <div>
                   <div class="text-caption">from {{ share.sharedBy?.name || share.sharedBy?.email }}</div>
-                  <div class="text-caption text-medium-emphasis" v-if="share.conversation?.updatedAt">
-                    {{ formatDate(share.conversation.updatedAt) }}
+                  <div class="text-caption text-medium-emphasis">
+                    {{ sharedConversationDateLabel(share) }}
                   </div>
                 </div>
               </template>
@@ -1532,6 +1532,46 @@ interface SharedConversationEntry {
   createdAt: string;
 }
 const sharedConversations = ref<SharedConversationEntry[]>([]);
+
+// The same sidebar search/sort/filter controls apply to "Shared with me". For
+// shared rows, "Date created" is interpreted as `share.createdAt` (when the
+// share landed in the recipient's list) rather than the conversation's own
+// createdAt, which isn't sent over the wire for shares. That's the more
+// useful semantic for the recipient anyway ("newest shares first").
+const filteredSharedConversations = computed(() => {
+  const q = conversationSearch.value.trim().toLowerCase();
+  const fmt = conversationFormatFilter.value;
+  const dir = conversationSortDir.value === 'desc' ? -1 : 1;
+  const key = conversationSortKey.value;
+
+  return [...sharedConversations.value]
+    .filter(s => {
+      const title = s.conversation?.title || '';
+      if (q && !title.toLowerCase().includes(q)) return false;
+      const format = s.conversation?.format;
+      if (fmt === 'standard' && format !== 'standard') return false;
+      if (fmt === 'group' && format === 'standard') return false;
+      return true;
+    })
+    .sort((a, b) => {
+      if (key === 'title') {
+        return (a.conversation?.title || '').localeCompare(b.conversation?.title || '') * dir;
+      }
+      // 'created' uses the share's createdAt (when received); 'updated' uses
+      // the conversation's updatedAt with a safe fallback.
+      const pickDate = (s: SharedConversationEntry) =>
+        key === 'created' ? s.createdAt : (s.conversation?.updatedAt || s.createdAt);
+      return (new Date(pickDate(a)).getTime() - new Date(pickDate(b)).getTime()) * dir;
+    });
+});
+
+// Row date for shared conversations, mirroring `conversationDateLabel` but
+// labeling the 'created' case as "received {date}" — clearer for shares.
+function sharedConversationDateLabel(s: SharedConversationEntry): string {
+  if (conversationSortKey.value === 'created') return `received ${formatDate(s.createdAt)}`;
+  if (s.conversation?.updatedAt) return `updated ${formatDate(s.conversation.updatedAt)}`;
+  return `received ${formatDate(s.createdAt)}`;
+}
 
 // Shares created by the current user (for owner to know their conversation is shared)
 interface MyCreatedShare {

--- a/deprecated-claude-app/frontend/src/views/ConversationView.vue
+++ b/deprecated-claude-app/frontend/src/views/ConversationView.vue
@@ -1253,7 +1253,7 @@
 
 <script setup lang="ts">
 import { ref, computed, onMounted, onBeforeUnmount, watch, nextTick } from 'vue';
-import { useRoute, useRouter } from 'vue-router';
+import { useRoute, useRouter, onBeforeRouteLeave } from 'vue-router';
 import { isEqual } from 'lodash-es';
 import { useStore } from '@/store';
 import { api } from '@/services/api';
@@ -3892,6 +3892,35 @@ watch(conversationSettingsDialog, async (isOpen, wasOpen) => {
   if (currentConversation.value?.id === discardId || route.params.id === discardId) {
     router.push('/conversation');
   }
+});
+
+// Browser back / sidebar nav / any route change away from a provisional
+// conversation should discard it too — the dialog-close watcher above
+// doesn't fire when the route guard tears down the component before the
+// dialog has a chance to close. Without this, hitting back during the
+// auto-opened settings dialog leaves the provisional conversation behind,
+// re-creating the very bug #99 was meant to fix.
+onBeforeRouteLeave(async (_to, from) => {
+  if (!provisionalNewConversationId.value) return;
+  const discardId = provisionalNewConversationId.value;
+  // Only act if we're navigating away from the provisional conversation itself.
+  if (from.params.id !== discardId) return;
+
+  // Clear the flag first so the dialog-close watcher (if it fires during
+  // teardown) short-circuits and we don't double-archive.
+  provisionalNewConversationId.value = null;
+  conversationSettingsDialog.value = false;
+
+  const hasContent =
+    currentConversation.value?.id === discardId && messages.value.length > 0;
+  if (hasContent) return;
+
+  try {
+    await store.archiveConversation(discardId);
+  } catch (e) {
+    console.error('Failed to discard provisional conversation on route leave:', e);
+  }
+  // Don't return false — navigation should proceed regardless.
 });
 
 async function switchToGroupChat() {

--- a/deprecated-claude-app/frontend/src/views/ConversationView.vue
+++ b/deprecated-claude-app/frontend/src/views/ConversationView.vue
@@ -1567,10 +1567,15 @@ const filteredSharedConversations = computed(() => {
 
 // Row date for shared conversations, mirroring `conversationDateLabel` but
 // labeling the 'created' case as "received {date}" — clearer for shares.
+// `s.createdAt` is typed as string but populated from API response; guard
+// against missing values to match the conditional-render intent the
+// pre-PR-#105 template had (Greptile #105 catch).
 function sharedConversationDateLabel(s: SharedConversationEntry): string {
-  if (conversationSortKey.value === 'created') return `received ${formatDate(s.createdAt)}`;
+  if (conversationSortKey.value === 'created') {
+    return s.createdAt ? `received ${formatDate(s.createdAt)}` : '';
+  }
   if (s.conversation?.updatedAt) return `updated ${formatDate(s.conversation.updatedAt)}`;
-  return `received ${formatDate(s.createdAt)}`;
+  return s.createdAt ? `received ${formatDate(s.createdAt)}` : '';
 }
 
 // Shares created by the current user (for owner to know their conversation is shared)
@@ -3940,7 +3945,7 @@ watch(conversationSettingsDialog, async (isOpen, wasOpen) => {
 // dialog has a chance to close. Without this, hitting back during the
 // auto-opened settings dialog leaves the provisional conversation behind,
 // re-creating the very bug #99 was meant to fix.
-onBeforeRouteLeave(async (_to, from) => {
+onBeforeRouteLeave((_to, from) => {
   if (!provisionalNewConversationId.value) return;
   const discardId = provisionalNewConversationId.value;
   // Only act if we're navigating away from the provisional conversation itself.
@@ -3955,12 +3960,14 @@ onBeforeRouteLeave(async (_to, from) => {
     currentConversation.value?.id === discardId && messages.value.length > 0;
   if (hasContent) return;
 
-  try {
-    await store.archiveConversation(discardId);
-  } catch (e) {
+  // Fire-and-forget. The guard must return synchronously — Vue Router 4
+  // awaits any Promise we return, which would stall the user's navigation
+  // (back button, sidebar click) on the archive API call. Greptile #105
+  // caught this: the previous `async` form did exactly that. Catch errors
+  // off the floating promise so they're still logged.
+  void store.archiveConversation(discardId).catch((e) => {
     console.error('Failed to discard provisional conversation on route leave:', e);
-  }
-  // Don't return false — navigation should proceed regardless.
+  });
 });
 
 async function switchToGroupChat() {


### PR DESCRIPTION
Two small extensions to simpolism's recently-merged PRs, surfaced by post-merge testing.

## 1. `#99` — back-nav also discards a provisional conversation

PR #99 cleans up the freshly-created \"New Conversation\" when the auto-opened settings dialog is dismissed via cancel / escape / backdrop. The dialog-close watcher handles those cases, but it doesn't fire when the user navigates away (browser back, or just clicks another conversation in the sidebar) while the dialog is still open — the route guard tears down `ConversationView.vue` before the dialog has a chance to close, so the discard logic never runs and the default-titled conversation is left behind. That's exactly the litter #99 was meant to prevent.

Adds `onBeforeRouteLeave` as the second tear-off path:
- Only acts when leaving the route for a provisional conversation.
- Clears the provisional flag *first* so the dialog-close watcher (if it does fire during teardown) short-circuits and we don't double-archive.
- Same content guard: a conversation with messages is never discarded.
- Doesn't block navigation — discard runs in the background and the user lands where they were going.

## 2. `#101` — sidebar search / sort / filter also covers \"Shared with me\"

PR #101 added the search / sort / filter controls above the main conversation list, but the \"Shared with me\" section below kept rendering raw `sharedConversations` unfiltered. Searching for a title would hide matches from the main list yet still show every share, and sort/filter selections were silently ignored for shared entries.

`filteredSharedConversations` mirrors the `conversations` computed:
- Same title-substring search.
- Same format filter (standard / group).
- Same sort direction and key.
- Sort by `'created'` uses `share.createdAt` (when the share was *received*) rather than the conversation's own createdAt — that field isn't sent over the wire for shares, and \"newest received\" is the more useful semantic for a recipient anyway. The row date label reflects this by saying \"received {date}\" instead of \"created {date}\" when in created-sort.
- The \"Shared with me\" subheader hides when the filtered list is empty, consistent with how the main list reacts to a no-match search.

## Scope / risk

Single file, two independent commits, +75/-6. `npm run build` passes. Both changes are localized to `ConversationView.vue` and don't touch shared state or other consumers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)