### PR TITLE
chore(ci): SHA-pin deploy actions and add typecheck scripts

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -60,10 +60,10 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
       with:
         node-version: '22.14.0'
         cache: 'npm'
@@ -151,7 +151,7 @@ jobs:
         esac
 
     - name: Deploy to server
-      uses: appleboy/ssh-action@v1.0.3
+      uses: appleboy/ssh-action@029f5b4aeeeb58fdfe1410a5d17f967dacf36262 # v1.0.3
       with:
         host: ${{ secrets.DEPLOY_HOST }}
         username: ${{ secrets.DEPLOY_USER }}
@@ -187,7 +187,7 @@ jobs:
           fi
 
     - name: Copy files to server
-      uses: appleboy/scp-action@v0.1.7
+      uses: appleboy/scp-action@917f8b81dfc1ccd331fef9e2d61bdc6c8be94634 # v0.1.7
       with:
         host: ${{ secrets.DEPLOY_HOST }}
         username: ${{ secrets.DEPLOY_USER }}
@@ -197,7 +197,7 @@ jobs:
         strip_components: 2
 
     - name: Install dependencies and start service
-      uses: appleboy/ssh-action@v1.0.3
+      uses: appleboy/ssh-action@029f5b4aeeeb58fdfe1410a5d17f967dacf36262 # v1.0.3
       with:
         host: ${{ secrets.DEPLOY_HOST }}
         username: ${{ secrets.DEPLOY_USER }}
@@ -251,7 +251,7 @@ jobs:
 
     - name: Health check
       if: steps.vars.outputs.health_url != ''
-      uses: appleboy/ssh-action@v1.0.3
+      uses: appleboy/ssh-action@029f5b4aeeeb58fdfe1410a5d17f967dacf36262 # v1.0.3
       with:
         host: ${{ secrets.DEPLOY_HOST }}
         username: ${{ secrets.DEPLOY_USER }}

--- a/deprecated-claude-app/backend/package.json
+++ b/deprecated-claude-app/backend/package.json
@@ -7,6 +7,7 @@
     "dev": "tsx watch src/index.ts",
     "dev:https": "USE_HTTPS=true tsx watch src/index.ts",
     "build": "tsc",
+    "typecheck": "tsc --noEmit",
     "start": "node dist/index.js",
     "start:https": "USE_HTTPS=true node dist/index.js",
     "import:claude-archive": "tsx scripts/import-claude-archive.ts",

--- a/deprecated-claude-app/package.json
+++ b/deprecated-claude-app/package.json
@@ -12,6 +12,7 @@
     "dev:backend": "npm run dev -w backend",
     "dev:frontend": "npm run dev -w frontend",
     "build": "npm run build -w shared && npm run build -w backend && npm run build -w frontend",
+    "typecheck": "npm run typecheck -w shared && npm run typecheck -w backend",
     "test": "npm run test --workspaces"
   },
   "devDependencies": {

--- a/deprecated-claude-app/shared/package.json
+++ b/deprecated-claude-app/shared/package.json
@@ -7,7 +7,8 @@
   "types": "./dist/index.d.ts",
   "scripts": {
     "build": "tsc",
-    "dev": "tsc --watch"
+    "dev": "tsc --watch",
+    "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
     "typescript": "^5.3.3"


### PR DESCRIPTION
Two small repo/CI hygiene items in one PR, separate commits.

## 1. `chore(ci)`: pin GitHub Action versions to commit SHAs

Tag-pinned actions can change underneath the workflow — the tag is a moving reference that any maintainer (legit or compromised) can repoint. Commit SHAs can't. This matters most for third-party actions like `appleboy/ssh-action` and `appleboy/scp-action` that run with deploy secrets in their environment; a compromised tag would have direct access to SSH keys and prod hosts.

All six `uses:` lines in `deploy-site.yml` are now pinned to the SHA the tag currently points at, with the tag retained as a comment so future maintainers can read what's in play and update intentionally:

| Action | Tag → SHA |
|---|---|
| `actions/checkout` | `v4` → `34e114876b0b11c390a56381ad16ebd13914f8d5` |
| `actions/setup-node` | `v4` → `49933ea5288caeca8642d1e84afbd3f7d6820020` |
| `appleboy/ssh-action` | `v1.0.3` → `029f5b4aeeeb58fdfe1410a5d17f967dacf36262` |
| `appleboy/scp-action` | `v0.1.7` → `917f8b81dfc1ccd331fef9e2d61bdc6c8be94634` |

SHAs are exactly what the tags resolved to at time of commit — no behavior change.

## 2. `chore(scripts)`: add `typecheck` npm scripts

No way to currently run a quick "does the type system still agree" check without running a full `build`. Adds `typecheck` scripts so contributors (and any future CI) can iterate faster:

- `backend`: `tsc --noEmit`
- `shared`:  `tsc --noEmit`
- root:      `npm run typecheck -w shared && npm run typecheck -w backend`

**Frontend is intentionally omitted.** `vue-tsc` 1.8.27 (the version pinned in `frontend/package.json`) is broken on Node 22 due to an upstream incompatibility — `npx vue-tsc --noEmit` aborts with `Search string not found: /supportedTSExtensions = .*(?=;)/` before checking anything. Upgrading vue-tsc to 2.x is the fix, but that's its own change (likely surfaces type errors that the old broken-on-22 setup was silently masking). Better to defer than ship a `typecheck` script that's secretly a no-op.

`npm run typecheck` from the project root passes clean for `shared` and `backend`.

## Scope / risk

Pure additions / non-behavioral edits. No runtime change. The deploy workflow still does the same things (just from pinned SHAs); the typecheck scripts are new entries that don't affect any existing flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)