### PR TITLE
feat(security): helmet headers + scope 50MB body limit to /api/import

### DIFF
--- a/deprecated-claude-app/backend/package.json
+++ b/deprecated-claude-app/backend/package.json
@@ -24,6 +24,7 @@
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
     "express-rate-limit": "8.5.1",
+    "helmet": "8.1.0",
     "jsonwebtoken": "^9.0.2",
     "multer": "^2.0.2",
     "resend": "^6.6.0",

--- a/deprecated-claude-app/backend/src/index.ts
+++ b/deprecated-claude-app/backend/src/index.ts
@@ -135,7 +135,7 @@ console.log('[HTTP] Gzip compression enabled (threshold: 1KB)');
 // only serves JSON — CSP is enforced by the frontend's own HTML response
 // served by nginx/Vite, not on API responses. `crossOriginResourcePolicy`
 // is loosened to allow the frontend (which is on a different origin during
-// local dev: localhost:5173 vs localhost:3000) to read API responses.
+// local dev: localhost:5173 vs localhost:3010) to read API responses.
 // Everything else helmet ships by default — HSTS, X-Content-Type-Options,
 // X-Frame-Options, Referrer-Policy, etc. — is on and useful.
 app.use(helmet({

--- a/deprecated-claude-app/backend/src/index.ts
+++ b/deprecated-claude-app/backend/src/index.ts
@@ -154,6 +154,12 @@ app.use(cors({
 // the import path so it consumes the body, then the smaller global default
 // applies to everything else (express.json is idempotent — re-parsing a
 // request whose body has already been consumed is a no-op).
+//
+// Auth gate runs BEFORE the 50MB parser on the import path so an
+// unauthenticated client can't make us buffer + JSON-parse a 50MB body
+// before being rejected. (Greptile #108 review caught this — the
+// abuse-surface narrowing was incomplete without the auth ordering.)
+app.use('/api/import', authenticateToken);
 app.use('/api/import', express.json({ limit: '50mb' }));
 app.use('/api/import', express.urlencoded({ limit: '50mb', extended: true }));
 app.use(express.json({ limit: '5mb' }));
@@ -167,7 +173,7 @@ app.use('/api/conversations', authenticateToken, conversationRouter(db));
 app.use('/api/models/custom', authenticateToken, customModelsRouter(db));
 app.use('/api/models', authenticateToken, modelRouter(db));
 app.use('/api/participants', authenticateToken, participantRouter(db));
-app.use('/api/import', authenticateToken, importRouter(db));
+app.use('/api/import', importRouter(db)); // authenticateToken already applied above (before body parser)
 app.use('/api/prompt', createPromptRouter(db));
 app.use('/api/shares', createShareRouter(db));
 app.use('/api/bookmarks', createBookmarksRouter(db));

--- a/deprecated-claude-app/backend/src/index.ts
+++ b/deprecated-claude-app/backend/src/index.ts
@@ -1,5 +1,6 @@
 import express from 'express';
 import compression from 'compression';
+import helmet from 'helmet';
 import { clearOpenRouterLog } from './utils/openrouterLogger.js';
 
 // Clean up old OpenRouter request logs on startup
@@ -129,6 +130,18 @@ app.use(compression({
   }
 }));
 console.log('[HTTP] Gzip compression enabled (threshold: 1KB)');
+
+// Security headers. `contentSecurityPolicy` is disabled because the backend
+// only serves JSON — CSP is enforced by the frontend's own HTML response
+// served by nginx/Vite, not on API responses. `crossOriginResourcePolicy`
+// is loosened to allow the frontend (which is on a different origin during
+// local dev: localhost:5173 vs localhost:3000) to read API responses.
+// Everything else helmet ships by default — HSTS, X-Content-Type-Options,
+// X-Frame-Options, Referrer-Policy, etc. — is on and useful.
+app.use(helmet({
+  contentSecurityPolicy: false,
+  crossOriginResourcePolicy: { policy: 'cross-origin' },
+}));
 
 app.use(cors({
   origin: process.env.FRONTEND_URL || 'http://localhost:5173',

--- a/deprecated-claude-app/backend/src/index.ts
+++ b/deprecated-claude-app/backend/src/index.ts
@@ -147,8 +147,17 @@ app.use(cors({
   origin: process.env.FRONTEND_URL || 'http://localhost:5173',
   credentials: true
 }));
-app.use(express.json({ limit: '50mb' }));
-app.use(express.urlencoded({ limit: '50mb', extended: true }));
+
+// Body parser limits. Import routes legitimately ingest large
+// conversation-history JSON (the /messages-raw endpoint, and similar);
+// nothing else needs more than a few MB. Mount the larger parser FIRST on
+// the import path so it consumes the body, then the smaller global default
+// applies to everything else (express.json is idempotent — re-parsing a
+// request whose body has already been consumed is a no-op).
+app.use('/api/import', express.json({ limit: '50mb' }));
+app.use('/api/import', express.urlencoded({ limit: '50mb', extended: true }));
+app.use(express.json({ limit: '5mb' }));
+app.use(express.urlencoded({ limit: '5mb', extended: true }));
 
 // Routes
 app.use('/api/auth', authRouter(db));

--- a/deprecated-claude-app/package-lock.json
+++ b/deprecated-claude-app/package-lock.json
@@ -12,14 +12,11 @@
         "frontend",
         "shared"
       ],
-      "dependencies": {
-        "@types/compression": "^1.8.1",
-        "@types/multer": "^2.0.0",
-        "compression": "^1.8.1",
-        "multer": "^2.0.2"
-      },
       "devDependencies": {
         "concurrently": "^8.2.2"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "backend": {
@@ -37,6 +34,7 @@
         "dotenv": "^16.3.1",
         "express": "^4.18.2",
         "express-rate-limit": "8.5.1",
+        "helmet": "8.1.0",
         "jsonwebtoken": "^9.0.2",
         "multer": "^2.0.2",
         "resend": "^6.6.0",
@@ -5456,6 +5454,15 @@
       "license": "MIT",
       "bin": {
         "he": "bin/he"
+      }
+    },
+    "node_modules/helmet": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.1.0.tgz",
+      "integrity": "sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/html2canvas": {


### PR DESCRIPTION
Two small Express-baseline hardening fixes in one PR, separate commits.

## 1. `feat(security)`: add helmet middleware for default security headers

Adds `helmet@8.1.0` so API responses ship with the standard security headers — `X-Content-Type-Options: nosniff`, `X-Frame-Options: SAMEORIGIN`, `Strict-Transport-Security`, `Referrer-Policy`, `Origin-Agent-Cluster`, `X-DNS-Prefetch-Control`, `X-Permitted-Cross-Domain-Policies`. Defense-in-depth: an attacker who finds a way to coax the browser into MIME-sniffing, framing, or referrer-leaking off an API response now has those vectors closed.

Two opt-outs from the helmet defaults, both intentional:

- **`contentSecurityPolicy: false`** — the backend serves JSON, not HTML. CSP is enforced on the frontend's own HTML response served by nginx/Vite, not on API responses. A CSP header on a JSON response has nothing to govern; enabling helmet's default would add noise with zero benefit.
- **`crossOriginResourcePolicy: { policy: 'cross-origin' }`** — in local development, frontend (`localhost:5173`) and backend (`localhost:3010`) are on different origins. helmet's default `'same-origin'` policy would block the frontend from reading API responses. Production deploys share an origin (single hostname with nginx routing `/api/*`), so the policy doesn't matter there, but the loosened setting works for both.

CORS posture is unchanged — the existing `cors()` middleware with `FRONTEND_URL` is what actually gates browser access; helmet's CORP is a parallel header layer.

## 2. `feat(security)`: scope 50MB body limit to `/api/import`; 5MB elsewhere

The global `express.json({ limit: '50mb' })` was a footgun — any unauthenticated POST to any endpoint (login, register, system config, analytics, etc.) could ship a 50MB body and tie up memory/CPU during parse. Auth and most other routes have no business taking more than a few KB.

The legitimate large-body case is import: `/api/import/messages-raw` ingests entire conversation histories as JSON. (Claude.ai archive uploads use multer with their own size cap, separate path.) Scope the 50MB allowance to that mount point:

```js
app.use('/api/import', express.json({ limit: '50mb' }));
app.use('/api/import', express.urlencoded({ limit: '50mb', extended: true }));
app.use(express.json({ limit: '5mb' }));
app.use(express.urlencoded({ limit: '5mb', extended: true }));
```

Order matters. Express body parsers are idempotent — the first parser to consume the request body wins, and subsequent parsers on the same request see `req.body` is already set and no-op. By mounting the larger import parser FIRST on `/api/import`, it gets the body for those routes; the smaller global default then handles everything else.

5MB global default leaves comfortable headroom: a long user message with several base64-encoded image attachments runs ~1-3MB, well under the cap. If something legitimate turns out to need more, easy bump.

## Scope / risk

Two commits, both additive/scoping-only in `index.ts` (+ helmet dep). Backend `npm run build` passes both intermediate states. No runtime change to functioning paths — only the abuse surface narrows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)