### PR TITLE
Provider service hygiene: env-overridable URLs, safe-log credential redaction, drop redundant DB call

### DIFF
--- a/deprecated-claude-app/backend/env.example
+++ b/deprecated-claude-app/backend/env.example
@@ -19,6 +19,10 @@ JWT_SECRET=your-secret-key-change-in-production
 # OPENAI_API_KEY=sk-...
 # OPENAI_BASE_URL=https://api.openai.com/v1
 
+# Provider base URLs (optional - defaults to each provider's public root)
+# OPENROUTER_BASE_URL=https://openrouter.ai/api/v1
+# GEMINI_BASE_URL=https://generativelanguage.googleapis.com/v1beta
+
 # AWS Bedrock Configuration (fallback)
 AWS_REGION=us-east-1
 # AWS_ACCESS_KEY_ID=your-access-key

--- a/deprecated-claude-app/backend/src/database/index.ts
+++ b/deprecated-claude-app/backend/src/database/index.ts
@@ -5045,7 +5045,10 @@ export class Database {
     // protection. If a per-user storage budget becomes desirable later,
     // implement it as an explicit per-tier policy rather than a hardcoded
     // ceiling here.
-    await this.getUserModels(userId);
+    // (Greptile #96: a `getUserModels(userId)` call used to live here as
+    // part of the cap-enforcement loop. Removed when the cap went away —
+    // its return value was discarded, and `loadUser` above already
+    // populated the in-memory model set.)
 
     // Resolve settings with validation
     let resolvedSettings = modelData.settings;

--- a/deprecated-claude-app/backend/src/services/anthropic.ts
+++ b/deprecated-claude-app/backend/src/services/anthropic.ts
@@ -2,6 +2,7 @@ import Anthropic from '@anthropic-ai/sdk';
 import { Message, getActiveBranch, ModelSettings } from '@deprecated-claude/shared';
 import { Database } from '../database/index.js';
 import { llmLogger } from '../utils/llmLogger.js';
+import { safeErrorLog } from '../utils/safe-log.js';
 import sharp from 'sharp';
 import { isImageFile } from './attachment-utils.js';
 
@@ -436,7 +437,7 @@ export class AnthropicService {
         }
       };
     } catch (error) {
-      console.error('Anthropic streaming error:', error);
+      safeErrorLog('Anthropic streaming error:', error);
       const errorMessage = error instanceof Error ? error.message : String(error);
       
       // Log the error

--- a/deprecated-claude-app/backend/src/services/bedrock.ts
+++ b/deprecated-claude-app/backend/src/services/bedrock.ts
@@ -2,6 +2,7 @@ import { BedrockRuntimeClient, InvokeModelWithResponseStreamCommand } from '@aws
 import { Message, getActiveBranch, ModelSettings } from '@deprecated-claude/shared';
 import { Database } from '../database/index.js';
 import { llmLogger } from '../utils/llmLogger.js';
+import { safeErrorLog } from '../utils/safe-log.js';
 import sharp from 'sharp';
 import { isImageFile } from './attachment-utils.js';
 
@@ -220,7 +221,7 @@ export class BedrockService {
 
       return { rawRequest };
     } catch (error) {
-      console.error('Bedrock streaming error:', error);
+      safeErrorLog('Bedrock streaming error:', error);
       
       // Log the error
       if (requestId) {

--- a/deprecated-claude-app/backend/src/services/gemini.ts
+++ b/deprecated-claude-app/backend/src/services/gemini.ts
@@ -1,6 +1,7 @@
 import { Message, getActiveBranch, ModelSettings, ContentBlock } from '@deprecated-claude/shared';
 import { Database } from '../database/index.js';
 import { getBlobStore } from '../database/blob-store.js';
+import { redactSecrets, safeErrorLog } from '../utils/safe-log.js';
 
 /**
  * Gemini API Service
@@ -232,8 +233,8 @@ export class GeminiService {
       
       if (!response.ok) {
         const errorText = await response.text();
-        console.error(`[Gemini API] Error ${response.status}:`, errorText);
-        throw new Error(`Gemini API error: ${response.status} ${errorText}`);
+        console.error(`[Gemini API] Error ${response.status}:`, redactSecrets(errorText));
+        throw new Error(`Gemini API error: ${response.status} ${redactSecrets(errorText)}`);
       }
       
       if (!response.body) {
@@ -452,7 +453,7 @@ export class GeminiService {
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
       const duration = Date.now() - startTime;
-      console.error(`[Gemini API] Request ${requestId} failed after ${duration}ms:`, errorMessage);
+      safeErrorLog(`[Gemini API] Request ${requestId} failed after ${duration}ms:`, error);
       
       // Estimate input tokens from request for cost tracking on failures
       // Google still charges for failed requests that were processed

--- a/deprecated-claude-app/backend/src/services/gemini.ts
+++ b/deprecated-claude-app/backend/src/services/gemini.ts
@@ -100,6 +100,10 @@ interface GeminiStreamChunk {
   };
 }
 
+// Google AI Studio's Gemini API root. Overridable via GEMINI_BASE_URL for
+// tests, proxies, and (eventually) Vertex AI compatibility shims.
+const GEMINI_DEFAULT_BASE_URL = 'https://generativelanguage.googleapis.com/v1beta';
+
 export class GeminiService {
   private apiKey: string;
   private baseUrl: string;
@@ -108,7 +112,7 @@ export class GeminiService {
   constructor(db: Database, apiKey?: string) {
     this.db = db;
     this.apiKey = apiKey || process.env.GEMINI_API_KEY || '';
-    this.baseUrl = 'https://generativelanguage.googleapis.com/v1beta';
+    this.baseUrl = process.env.GEMINI_BASE_URL || GEMINI_DEFAULT_BASE_URL;
     
     if (!this.apiKey) {
       console.error('⚠️ API KEY ERROR: No Gemini API key provided. Set GEMINI_API_KEY environment variable or configure user API keys. Gemini API calls will fail.');

--- a/deprecated-claude-app/backend/src/services/inference.ts
+++ b/deprecated-claude-app/backend/src/services/inference.ts
@@ -8,6 +8,7 @@ import { GeminiService } from './gemini.js';
 import { ApiKeyManager } from './api-key-manager.js';
 import { ModelLoader } from '../config/model-loader.js';
 import { Logger } from '../utils/logger.js';
+import { redactSecrets } from '../utils/safe-log.js';
 import { ContextManager } from './context-manager.js';
 import { isImageFile } from './attachment-utils.js';
 
@@ -328,7 +329,7 @@ export class InferenceService {
         }
       }
     } else {
-      console.log(`[InferenceService] Using custom model with embedded endpoint: ${(model as any).customEndpoint.baseUrl}`);
+      console.log(`[InferenceService] Using custom model with embedded endpoint: ${redactSecrets((model as any).customEndpoint.baseUrl)}`);
     }
 
     // Track token usage
@@ -658,7 +659,7 @@ export class InferenceService {
         ? undefined
         : selectedKey?.credentials.modelPrefix;
       
-      console.log(`[InferenceService] OpenAI-compatible model config: isCustomModel=${isCustomModel}, baseUrl=${baseUrl}`);
+      console.log(`[InferenceService] OpenAI-compatible model config: isCustomModel=${isCustomModel}, baseUrl=${redactSecrets(baseUrl)}`);
       
       const openAIService = new OpenAICompatibleService(
         this.db,

--- a/deprecated-claude-app/backend/src/services/openai-compatible.ts
+++ b/deprecated-claude-app/backend/src/services/openai-compatible.ts
@@ -1,6 +1,7 @@
 import { Message, getActiveBranch, ModelSettings, TokenUsage } from '@deprecated-claude/shared';
 import { Database } from '../database/index.js';
 import { llmLogger } from '../utils/llmLogger.js';
+import { redactSecrets, safeErrorLog } from '../utils/safe-log.js';
 
 interface OpenAIMessage {
   role: 'user' | 'assistant' | 'system';
@@ -95,10 +96,14 @@ export class OpenAICompatibleService {
 
       if (!response.ok) {
         const errorText = await response.text();
-        console.error(`[OpenAI-Compatible] Error response:`, errorText);
-        console.error(`[OpenAI-Compatible] Request URL was: ${endpoint}`);
+        // `endpoint` may be a user-configured custom-model baseUrl that
+        // embeds an API key in the query string or as inline auth; redact
+        // before logging. `errorText` from the upstream provider can echo
+        // request fragments back, so redact that too.
+        console.error(`[OpenAI-Compatible] Error response:`, redactSecrets(errorText));
+        console.error(`[OpenAI-Compatible] Request URL was: ${redactSecrets(endpoint)}`);
         console.error(`[OpenAI-Compatible] Model ID was: ${actualModelId}`);
-        throw new Error(`OpenAI-compatible API error: ${response.status} ${response.statusText} - ${errorText}`);
+        throw new Error(`OpenAI-compatible API error: ${response.status} ${response.statusText} - ${redactSecrets(errorText)}`);
       }
 
       const reader = response.body?.getReader();
@@ -171,8 +176,8 @@ export class OpenAICompatibleService {
       
       return { rawRequest: requestBody };
     } catch (error) {
-      console.error('OpenAI-compatible streaming error:', error);
-      
+      safeErrorLog('OpenAI-compatible streaming error:', error);
+
       // Log the error
       const duration = Date.now() - startTime;
       await llmLogger.logResponse({
@@ -294,7 +299,7 @@ export class OpenAICompatibleService {
       const data = await response.json();
       return (data as any)?.data || [];
     } catch (error) {
-      console.error('Failed to list models:', error);
+      safeErrorLog('Failed to list models:', error);
       return [];
     }
   }

--- a/deprecated-claude-app/backend/src/services/openrouter.ts
+++ b/deprecated-claude-app/backend/src/services/openrouter.ts
@@ -4,6 +4,7 @@ import { getBlobStore } from '../database/blob-store.js';
 import { llmLogger } from '../utils/llmLogger.js';
 import { Logger } from '../utils/logger.js';
 import { logOpenRouterRequest, logOpenRouterResponse } from '../utils/openrouterLogger.js';
+import { safeErrorLog } from '../utils/safe-log.js';
 import { isImageFile } from './attachment-utils.js';
 
 interface OpenRouterMessage {
@@ -720,7 +721,7 @@ export class OpenRouterService {
       
       return { rawRequest: requestBody }; // No usage data available
     } catch (error) {
-      console.error('OpenRouter streaming error:', error);
+      safeErrorLog('OpenRouter streaming error:', error);
       const errorMessage = error instanceof Error ? error.message : String(error);
       
       // Log the error
@@ -988,7 +989,7 @@ export class OpenRouterService {
       const data = await response.json();
       return (data as any)?.data || [];
     } catch (error) {
-      console.error('Failed to list OpenRouter models:', error);
+      safeErrorLog('Failed to list OpenRouter models:', error);
       return [];
     }
   }

--- a/deprecated-claude-app/backend/src/services/openrouter.ts
+++ b/deprecated-claude-app/backend/src/services/openrouter.ts
@@ -57,14 +57,19 @@ interface OpenRouterResponse {
   };
 }
 
+// OpenRouter's public API root. Overridable via OPENROUTER_BASE_URL for
+// tests, proxies, and self-hosted reverse-proxy setups.
+const OPENROUTER_DEFAULT_BASE_URL = 'https://openrouter.ai/api/v1';
+
 export class OpenRouterService {
   private db: Database;
   private apiKey: string;
-  private baseUrl = 'https://openrouter.ai/api/v1';
+  private baseUrl: string;
 
   constructor(db: Database, apiKey?: string) {
     this.db = db;
     this.apiKey = apiKey || process.env.OPENROUTER_API_KEY || '';
+    this.baseUrl = process.env.OPENROUTER_BASE_URL || OPENROUTER_DEFAULT_BASE_URL;
     
     if (!this.apiKey) {
       console.error('⚠️ API KEY ERROR: No OpenRouter API key provided. Set OPENROUTER_API_KEY environment variable or configure user API keys. OpenRouter API calls will fail.');

--- a/deprecated-claude-app/backend/src/utils/safe-log.ts
+++ b/deprecated-claude-app/backend/src/utils/safe-log.ts
@@ -1,0 +1,116 @@
+/**
+ * Secret-redacting log helpers.
+ *
+ * The provider services hit external HTTP endpoints with URLs and headers
+ * that frequently carry credentials — Authorization bearer tokens, API keys
+ * embedded in URL query strings, and the occasional `user:pass@host` inline
+ * auth from a custom-model baseUrl. When those requests fail, the natural
+ * `console.error(err)` pattern dumps `err.config` (axios) or the stringified
+ * Error (fetch) into the log, which silently surfaces the credentials.
+ *
+ * `safeErrorLog` and the underlying `redactSecrets` give a single place to
+ * scrub those values before they hit stdout. Cheap, targeted, and bounded
+ * to the patterns we actually emit — it is *not* a general-purpose log
+ * scrubber, and won't catch creative new exfiltration shapes that future
+ * code introduces. New leak surfaces should add cases here.
+ *
+ * The three patterns are designed to be non-overlapping: each matches a
+ * distinct context (URL inline auth, URL query, header/JSON), and the
+ * replacement leaves a `[REDACTED]` token that the other patterns won't
+ * re-match (the body class excludes `[`).
+ */
+
+// 1. Inline auth in URLs: `https://user:pass@host/path`
+const INLINE_AUTH_RE = /([a-z][a-z0-9+.-]*:\/\/)([^@/?#\s]+):([^@/?#\s]+)@/gi;
+
+// 2. URL query-string secrets: `?api_key=...`, `&token=...`, etc.
+// Body stops at any URL delimiter so multiple params get redacted
+// independently rather than the first one eating the rest.
+const QUERY_SECRET_RE =
+  /([?&])([a-z0-9_.-]*(?:api[_-]?key|token|secret|password|auth|sig|signature)[a-z0-9_.-]*)=[^&#\s'"]*/gi;
+
+// 3. Header-like contexts: `Authorization: Bearer xxx`, `"x-api-key":"sk-..."`,
+// `x-api-key=...` in a free-form log line. Body class is alphanumeric + a
+// few token-friendly punctuation chars, which intentionally excludes `[`
+// — so a previously-redacted `[REDACTED]` value can't be re-matched.
+const HEADER_RE =
+  /((?:authorization|(?:x-)?api[_-]?key)['"]?\s*[:=]\s*['"]?(?:Bearer\s+)?)[A-Za-z0-9._\-+/=]{4,}/gi;
+
+/**
+ * Strip likely-credential substrings from a string. Designed to be applied
+ * to URLs, error messages, and stringified objects on their way to a log.
+ *
+ * - `https://user:secret@host/path`              → `https://user:[REDACTED]@host/path`
+ * - `?api_key=abc&token=xyz`                     → `?api_key=[REDACTED]&token=[REDACTED]`
+ * - `Authorization: Bearer eyJ...`               → `Authorization: Bearer [REDACTED]`
+ * - `"x-api-key": "sk-..."`                      → `"x-api-key": "[REDACTED]"`
+ *
+ * Anything not matching one of these shapes passes through unchanged.
+ */
+export function redactSecrets(s: string): string {
+  if (!s) return s;
+  return s
+    .replace(INLINE_AUTH_RE, '$1$2:[REDACTED]@')
+    .replace(QUERY_SECRET_RE, '$1$2=[REDACTED]')
+    .replace(HEADER_RE, '$1[REDACTED]');
+}
+
+/**
+ * Format an error for logging with secrets redacted. Preserves the stack
+ * (useful for debugging) but scrubs URLs and headers from both the
+ * message and the stack body.
+ */
+export function formatError(error: unknown): string {
+  if (error instanceof Error) {
+    const head = `${error.name}: ${error.message}`;
+    // Node's Error.stack starts with `${name}: ${message}\n`. Avoid double-printing.
+    const stackBody =
+      error.stack && error.stack.startsWith(head)
+        ? error.stack.slice(head.length)
+        : error.stack
+          ? `\n${error.stack}`
+          : '';
+    return redactSecrets(head + stackBody);
+  }
+  if (error && typeof error === 'object') {
+    try {
+      return redactSecrets(JSON.stringify(error));
+    } catch {
+      return redactSecrets(String(error));
+    }
+  }
+  return redactSecrets(String(error));
+}
+
+/**
+ * Drop-in replacement for `console.error(prefix, error, ...extra)` that
+ * redacts known credential shapes from the error and any string extras.
+ *
+ * Non-string `extra` values are JSON-stringified before redaction. Pass
+ * structured data here rather than embedding it in `prefix`.
+ */
+export function safeErrorLog(
+  prefix: string,
+  error: unknown,
+  ...extra: unknown[]
+): void {
+  const formatted = formatError(error);
+  if (extra.length === 0) {
+    console.error(prefix, formatted);
+    return;
+  }
+  const extras = extra.map((e) =>
+    typeof e === 'string'
+      ? redactSecrets(e)
+      : redactSecrets(safeStringify(e)),
+  );
+  console.error(prefix, formatted, ...extras);
+}
+
+function safeStringify(value: unknown): string {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}

--- a/deprecated-claude-app/backend/src/utils/safe-log.ts
+++ b/deprecated-claude-app/backend/src/utils/safe-log.ts
@@ -26,15 +26,32 @@ const INLINE_AUTH_RE = /([a-z][a-z0-9+.-]*:\/\/)([^@/?#\s]+):([^@/?#\s]+)@/gi;
 // 2. URL query-string secrets: `?api_key=...`, `&token=...`, etc.
 // Body stops at any URL delimiter so multiple params get redacted
 // independently rather than the first one eating the rest.
+//
+// Two alternatives in the keyword group:
+//   - long, unambiguous names (api_key, token, secret, password, signature)
+//     can sit anywhere in a compound param name (`my_api_key_v2`, etc.)
+//   - short, ambiguous names (auth, sig) must be the WHOLE param name —
+//     otherwise we'd silently redact `?author=name`, `?signature_date=...`,
+//     etc. Greptile #109 caught this — `auth` and `sig` were matching as
+//     substrings inside longer names. The surrounding `([?&])` and `=`
+//     already anchor word edges for these, so no explicit `\b` is needed.
 const QUERY_SECRET_RE =
-  /([?&])([a-z0-9_.-]*(?:api[_-]?key|token|secret|password|auth|sig|signature)[a-z0-9_.-]*)=[^&#\s'"]*/gi;
+  /([?&])((?:[a-z0-9_.-]*(?:api[_-]?key|token|secret|password|signature)[a-z0-9_.-]*)|(?:auth|sig))=[^&#\s'"]*/gi;
 
 // 3. Header-like contexts: `Authorization: Bearer xxx`, `"x-api-key":"sk-..."`,
-// `x-api-key=...` in a free-form log line. Body class is alphanumeric + a
-// few token-friendly punctuation chars, which intentionally excludes `[`
-// — so a previously-redacted `[REDACTED]` value can't be re-matched.
+// `x-api-key=...` in a free-form log line. The scheme group
+// `(?:[A-Za-z]+\s+)?` consumes ANY auth scheme word (Bearer, Basic, Token,
+// ApiKey, …) before the credential body, not just `Bearer`. Greptile #109
+// caught the original `(?:Bearer\s+)?` silently failing on
+// `Authorization: Basic dXNl…` — the optional group matched empty, the
+// body class consumed the word `Basic`, and the actual credential survived
+// into the log.
+//
+// Body class is alphanumeric + a few token-friendly punctuation chars,
+// which intentionally excludes `[` — so a previously-redacted `[REDACTED]`
+// value can't be re-matched by another pattern.
 const HEADER_RE =
-  /((?:authorization|(?:x-)?api[_-]?key)['"]?\s*[:=]\s*['"]?(?:Bearer\s+)?)[A-Za-z0-9._\-+/=]{4,}/gi;
+  /((?:authorization|(?:x-)?api[_-]?key)['"]?\s*[:=]\s*['"]?(?:[A-Za-z]+\s+)?)[A-Za-z0-9._\-+/=]{4,}/gi;
 
 /**
  * Strip likely-credential substrings from a string. Designed to be applied


### PR DESCRIPTION
Three backend provider/service hygiene fixes in one PR, separate commits, all from REVIEW_FINDINGS Tier 2.

## 1. `chore(providers)`: extract base URLs to env-overridable constants (P2-22)

`OpenRouterService` and `GeminiService` carried their API roots as literal in-class field assignments. Fine for the happy path but blocks legitimate overrides — tests against a mock server, internal reverse-proxies, region-local mirrors, the eventual Vertex AI compatibility shim for Gemini. Existing `OPENAI_BASE_URL` already follows this pattern.

Both services now read `process.env.{OPENROUTER,GEMINI}_BASE_URL` with the public root as fallback. `env.example` documents both new vars (commented; defaults are correct for almost every deployment). No behavior change unless an operator opts in.

## 2. `feat(security)`: add `safeErrorLog` / `redactSecrets` and apply across providers (P2-9 + P2-24)

Provider error logs ship credentials in two recurring shapes:

1. Catch-all `console.error('… streaming error:', error)` in each provider dumps the full Error/Axios object. Fetch-style errors embed the URL (with potential `https://user:pass@…` inline auth and `?api_key=…` query params) in the message; Axios-style errors carry it in `err.config`.
2. Explicit URL logs — `openai-compatible.ts:99` (`Request URL was: ${endpoint}`) and `inference.ts:331,661` (custom-model `baseUrl` interpolation) — directly emit user-configured custom-model URLs that may carry credentials in the URL itself.

New `utils/safe-log.ts` with two helpers:

- **`redactSecrets(s)`** scrubs three non-overlapping shapes:
  - Inline URL auth `user:pass@host` → `user:[REDACTED]@host`
  - Query secrets `?api_key=x&token=y` → `?api_key=[REDACTED]&token=[REDACTED]`
  - Header/JSON contexts `Authorization: Bearer x`, `\"x-api-key\":\"sk-…\"` → `[REDACTED]`
  - The `[REDACTED]` marker's character class excludes `[`, so the three regexes can't re-match each other's output — avoids the `[REDACTED] [REDACTED]` double-redaction class of bug that an earlier draft had.

- **`safeErrorLog(prefix, error, ...extra)`** is a drop-in `console.error` replacement that runs `formatError` (preserves name/message/stack) through `redactSecrets` before printing.

Applied at the highest-risk sites — catch-all streaming-error handlers in all five providers, plus the explicit URL-interpolation logs. Smoke-tested with the patterns in the doc block: inline auth, multi-secret URLs (`?api_key=a&token=b&signature=c` all redacted, non-secret `&other=fine` preserved), bearer headers, JSON header variants, and plain text — all behave as documented.

Not a general-purpose scrubber. Bounded to patterns we actually emit; new leak shapes should extend `safe-log.ts` directly.

## 3. `chore(backend)`: drop redundant `getUserModels()` call (Greptile #96 follow-up)

Greptile flagged on PR #96: in the custom-model creation path, after `await this.loadUser(userId)`, there's an `await this.getUserModels(userId)` whose return value is discarded. It existed as part of the now-removed 20-model cap enforcement loop. `loadUser` above already populates the in-memory model set; the call became a no-op that just costs one extra DB read per custom-model creation. Removed, with an inline comment pointing at the removed call's history so the next reader doesn't reintroduce it.

## Scope / risk

Three commits, all backend, all additive or non-behavioral. Backend `npm run build` passes each intermediate state. No runtime change unless an operator sets the new env vars or hits a previously-leaky error path (in which case the log is now scrubbed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)