### PR TITLE
Operational defensive baseline: strict test-user gate, avatar quota, Node engines

### DIFF
--- a/deprecated-claude-app/backend/package.json
+++ b/deprecated-claude-app/backend/package.json
@@ -42,5 +42,8 @@
     "@types/uuid": "^9.0.8",
     "tsx": "^4.7.0",
     "typescript": "^5.3.3"
+  },
+  "engines": {
+    "node": ">=22"
   }
 }

--- a/deprecated-claude-app/backend/src/database/index.ts
+++ b/deprecated-claude-app/backend/src/database/index.ts
@@ -189,8 +189,20 @@ export class Database {
       this.userLastAccessedTimes.set(id, new Date());
     }
     
-    // Create test users only in development
-    if (process.env.NODE_ENV !== 'production') {
+    // Create test users only in environments where they're EXPLICITLY allowed.
+    //
+    // The previous gate (`NODE_ENV !== 'production'`) failed open: an unset,
+    // empty, misspelled, or differently-cased NODE_ENV (`prod`, `Production`,
+    // ``) would silently put test users — with known credentials — into a
+    // production deployment. The fix is an allowlist: require an explicit
+    // dev/test NODE_ENV, OR an explicit ENABLE_TEST_USERS opt-in for the
+    // edge cases where neither env var is conventional. Anything else,
+    // including all misconfigurations, gets the safe default of no test users.
+    const allowTestUsers =
+      process.env.NODE_ENV === 'development' ||
+      process.env.NODE_ENV === 'test' ||
+      process.env.ENABLE_TEST_USERS === 'true';
+    if (allowTestUsers) {
       if (this.users.size === 0) {
         await this.createTestUser();
         console.log('🧪 Creating additional test users...');

--- a/deprecated-claude-app/backend/src/routes/avatars.ts
+++ b/deprecated-claude-app/backend/src/routes/avatars.ts
@@ -40,12 +40,21 @@ const USER_PACKS_PATH = path.join(AVATARS_BASE_PATH, 'users');
 // avatars after sharp's webp@quality:90 land at 10–100 KB typically,
 // so this allows 500+ avatars per user. Override with AVATAR_USER_QUOTA_MB
 // for ops that want to tune it.
+//
+// Greptile #110 caught the silent-fallback footgun: setting the env var
+// to "0" or any non-positive value used to fall through to the 50 MB
+// default without warning, so an operator trying to lock uploads down
+// would get the opposite of what they configured. Log a warning when
+// the var is set but unusable.
+const _rawAvatarQuotaMB = Number(process.env.AVATAR_USER_QUOTA_MB);
+if (process.env.AVATAR_USER_QUOTA_MB !== undefined && !(_rawAvatarQuotaMB > 0)) {
+  console.warn(
+    `[Avatars] AVATAR_USER_QUOTA_MB="${process.env.AVATAR_USER_QUOTA_MB}" is not a positive number; ` +
+    `falling back to 50 MB default. To disable uploads entirely, gate at a higher layer (e.g. nginx).`,
+  );
+}
 const AVATAR_USER_QUOTA_BYTES =
-  (Number(process.env.AVATAR_USER_QUOTA_MB) > 0
-    ? Number(process.env.AVATAR_USER_QUOTA_MB)
-    : 50) *
-  1024 *
-  1024;
+  (_rawAvatarQuotaMB > 0 ? _rawAvatarQuotaMB : 50) * 1024 * 1024;
 
 console.log(
   `[Avatars] Using avatar storage path: ${AVATARS_BASE_PATH} ` +
@@ -85,6 +94,46 @@ async function getUserAvatarsUsage(userId: string): Promise<number> {
   };
   await walk(userPath);
   return total;
+}
+
+/**
+ * Per-user serialization for the quota-check + write sequence. Greptile
+ * #110 caught the race: two concurrent uploads from the same user both
+ * read pre-write usage, both pass the quota check, both write, and the
+ * combined writes push the user over the cap. JS being single-threaded
+ * means the read-modify-write IS atomic in CPU terms, but it spans
+ * await points (fs I/O), so the only fix is a logical lock.
+ *
+ * Implementation is a chain of promises keyed by userId. Each call
+ * synchronously registers its "slot" (a manually-resolved Promise) as
+ * the new tail of the chain so the next caller sees it as predecessor;
+ * then waits for the previous tail before running `fn`. JS's
+ * single-threaded execution makes the synchronous read+register+set
+ * sequence atomic relative to other calls. The map entry is cleaned up
+ * when the last queued holder finishes, so memory doesn't grow
+ * unboundedly with the user set.
+ *
+ * Caveats: in-process only — multiple Node processes (PM2 cluster
+ * mode, multi-host) would not coordinate. Matches the rest of the
+ * write-path posture (single-process write safety, see P1-7) so it's
+ * not a regression; revisit if/when horizontal scale lands.
+ */
+const userUploadLocks = new Map<string, Promise<void>>();
+async function withUserUploadLock<T>(userId: string, fn: () => Promise<T>): Promise<T> {
+  const prev = userUploadLocks.get(userId) ?? Promise.resolve();
+  let releaseSlot!: () => void;
+  const slot = new Promise<void>((resolve) => { releaseSlot = resolve; });
+  userUploadLocks.set(userId, slot);
+  try {
+    await prev;
+    return await fn();
+  } finally {
+    releaseSlot();
+    // Only drop the entry if no one else queued after us.
+    if (userUploadLocks.get(userId) === slot) {
+      userUploadLocks.delete(userId);
+    }
+  }
 }
 
 // Validate IDs used in file paths to prevent path traversal
@@ -380,46 +429,60 @@ router.post('/packs/:packId/avatars', upload.single('avatar'), async (req: Multe
       return res.status(404).json({ error: 'Pack not found' });
     }
 
-    // Quota check: refuse if this upload would push the user past their
-    // per-user avatar disk allowance. Multer's 5 MB-per-file cap stops a
-    // single huge file but does nothing about many small files
-    // accumulating; this is the cumulative-bytes gate.
+    // Quota check + write under a per-user lock so two concurrent uploads
+    // from the same user can't both pass the pre-write check and end up
+    // pushing the user over the cap. Greptile #110 race fix: without the
+    // lock, parallel requests would both see pre-upload usage, both pass,
+    // both write — totalling past the limit.
     //
-    // Uses the incoming buffer size as an upper bound for the post-resize
+    // Multer's 5 MB-per-file cap stops a single huge file but does
+    // nothing about many small files accumulating. The cumulative gate
+    // uses the incoming buffer size as an upper bound for the post-resize
     // footprint (sharp generally shrinks). Approximate-but-safe: errors
     // toward rejecting borderline uploads rather than letting the user
     // creep past the cap.
-    const usage = await getUserAvatarsUsage(userId);
-    if (usage + req.file.size > AVATAR_USER_QUOTA_BYTES) {
-      const usedMB = (usage / (1024 * 1024)).toFixed(1);
-      const quotaMB = Math.round(AVATAR_USER_QUOTA_BYTES / (1024 * 1024));
+    const result = await withUserUploadLock(userId, async () => {
+      const usage = await getUserAvatarsUsage(userId);
+      if (usage + req.file!.size > AVATAR_USER_QUOTA_BYTES) {
+        const usedMB = (usage / (1024 * 1024)).toFixed(1);
+        const quotaMB = Math.round(AVATAR_USER_QUOTA_BYTES / (1024 * 1024));
+        return {
+          quotaExceeded: true as const,
+          details: `Using ${usedMB} MB of ${quotaMB} MB; this upload would exceed the limit. Delete unused avatars or contact an admin to raise the cap.`,
+        };
+      }
+
+      // Process image and create thumbnail
+      const originalExt = path.extname(req.file!.originalname);
+      const { thumbnail, original } = await processAndSaveAvatar(
+        req.file!.buffer,
+        packPath,
+        canonicalId,
+        originalExt
+      );
+
+      // Update pack.json with thumbnail (used for display) and original reference
+      pack.avatars[canonicalId] = thumbnail;
+      if (!pack.originals) pack.originals = {};
+      pack.originals[canonicalId] = original;
+      await writePackJson(packPath, pack);
+
+      return { quotaExceeded: false as const, thumbnail, original };
+    });
+
+    if (result.quotaExceeded) {
       return res.status(413).json({
         error: 'Avatar storage quota exceeded',
-        details: `Using ${usedMB} MB of ${quotaMB} MB; this upload would exceed the limit. Delete unused avatars or contact an admin to raise the cap.`,
+        details: result.details,
       });
     }
 
-    // Process image and create thumbnail
-    const originalExt = path.extname(req.file.originalname);
-    const { thumbnail, original } = await processAndSaveAvatar(
-      req.file.buffer,
-      packPath,
+    res.json({
+      success: true,
       canonicalId,
-      originalExt
-    );
-
-    // Update pack.json with thumbnail (used for display) and original reference
-    pack.avatars[canonicalId] = thumbnail;
-    if (!pack.originals) pack.originals = {};
-    pack.originals[canonicalId] = original;
-    await writePackJson(packPath, pack);
-
-    res.json({ 
-      success: true, 
-      canonicalId, 
-      thumbnail,
-      original,
-      path: `/avatars/users/${userId}/${packId}/${thumbnail}`
+      thumbnail: result.thumbnail,
+      original: result.original,
+      path: `/avatars/users/${userId}/${packId}/${result.thumbnail}`
     });
   } catch (error) {
     console.error('Error uploading avatar:', error);

--- a/deprecated-claude-app/backend/src/routes/avatars.ts
+++ b/deprecated-claude-app/backend/src/routes/avatars.ts
@@ -36,7 +36,56 @@ const AVATARS_BASE_PATH = getAvatarsBasePath();
 const SYSTEM_PACKS_PATH = path.join(AVATARS_BASE_PATH, 'system');
 const USER_PACKS_PATH = path.join(AVATARS_BASE_PATH, 'users');
 
-console.log(`[Avatars] Using avatar storage path: ${AVATARS_BASE_PATH}`);
+// Per-user disk quota for uploaded avatars. 50 MB is generous —
+// avatars after sharp's webp@quality:90 land at 10–100 KB typically,
+// so this allows 500+ avatars per user. Override with AVATAR_USER_QUOTA_MB
+// for ops that want to tune it.
+const AVATAR_USER_QUOTA_BYTES =
+  (Number(process.env.AVATAR_USER_QUOTA_MB) > 0
+    ? Number(process.env.AVATAR_USER_QUOTA_MB)
+    : 50) *
+  1024 *
+  1024;
+
+console.log(
+  `[Avatars] Using avatar storage path: ${AVATARS_BASE_PATH} ` +
+  `(per-user quota: ${Math.round(AVATAR_USER_QUOTA_BYTES / (1024 * 1024))} MB)`,
+);
+
+/**
+ * Sum of all file sizes under the user's avatar tree. Returns 0 if the
+ * user has no avatar dir yet. Walks recursively because each user has a
+ * `<packId>/` subdir per pack containing thumbnails + originals.
+ */
+async function getUserAvatarsUsage(userId: string): Promise<number> {
+  if (!isSafeId(userId)) return 0;
+  const userPath = path.join(USER_PACKS_PATH, userId);
+  let total = 0;
+  const walk = async (dir: string): Promise<void> => {
+    let entries;
+    try {
+      entries = await fs.readdir(dir, { withFileTypes: true });
+    } catch (e: any) {
+      if (e.code === 'ENOENT') return;
+      throw e;
+    }
+    for (const ent of entries) {
+      const full = path.join(dir, ent.name);
+      if (ent.isDirectory()) {
+        await walk(full);
+      } else if (ent.isFile()) {
+        try {
+          const st = await fs.stat(full);
+          total += st.size;
+        } catch {
+          // File vanished between readdir and stat — ignore, treat as 0.
+        }
+      }
+    }
+  };
+  await walk(userPath);
+  return total;
+}
 
 // Validate IDs used in file paths to prevent path traversal
 const SAFE_ID_RE = /^[a-zA-Z0-9_-]+$/;
@@ -329,6 +378,25 @@ router.post('/packs/:packId/avatars', upload.single('avatar'), async (req: Multe
 
     if (!pack) {
       return res.status(404).json({ error: 'Pack not found' });
+    }
+
+    // Quota check: refuse if this upload would push the user past their
+    // per-user avatar disk allowance. Multer's 5 MB-per-file cap stops a
+    // single huge file but does nothing about many small files
+    // accumulating; this is the cumulative-bytes gate.
+    //
+    // Uses the incoming buffer size as an upper bound for the post-resize
+    // footprint (sharp generally shrinks). Approximate-but-safe: errors
+    // toward rejecting borderline uploads rather than letting the user
+    // creep past the cap.
+    const usage = await getUserAvatarsUsage(userId);
+    if (usage + req.file.size > AVATAR_USER_QUOTA_BYTES) {
+      const usedMB = (usage / (1024 * 1024)).toFixed(1);
+      const quotaMB = Math.round(AVATAR_USER_QUOTA_BYTES / (1024 * 1024));
+      return res.status(413).json({
+        error: 'Avatar storage quota exceeded',
+        details: `Using ${usedMB} MB of ${quotaMB} MB; this upload would exceed the limit. Delete unused avatars or contact an admin to raise the cap.`,
+      });
     }
 
     // Process image and create thumbnail

--- a/deprecated-claude-app/frontend/package.json
+++ b/deprecated-claude-app/frontend/package.json
@@ -36,5 +36,8 @@
     "vite": "^5.0.11",
     "vite-plugin-vuetify": "^2.0.1",
     "vue-tsc": "^1.8.27"
+  },
+  "engines": {
+    "node": ">=22"
   }
 }

--- a/deprecated-claude-app/shared/package.json
+++ b/deprecated-claude-app/shared/package.json
@@ -14,5 +14,8 @@
   },
   "dependencies": {
     "zod": "^3.22.4"
+  },
+  "engines": {
+    "node": ">=22"
   }
 }


### PR DESCRIPTION
Three small operational-safety items from the Tier 1 queue, separate commits.

## 1. `fix(security)`: require explicit env-var opt-in to create test users

The previous gate — `if (NODE_ENV !== 'production')` — fails open. An unset, empty, misspelled, or differently-cased `NODE_ENV` (`prod`, `Production`, ``) silently bypasses the check and creates test users with known credentials on what is effectively a prod host.

Replaces the negative check with an explicit allowlist:

```js
NODE_ENV === 'development' || NODE_ENV === 'test'
  || ENABLE_TEST_USERS === 'true'
```

Conventional local-dev (`NODE_ENV=development`) and conventional CI test runs (`NODE_ENV=test`) keep working unchanged. The `ENABLE_TEST_USERS` opt-in covers edge cases. Anything else — including every shape of misconfiguration — gets the safe default of no test users.

## 2. `feat(security)`: per-user avatar disk quota (default 50 MB)

Multer's 5 MB-per-file cap stops a single huge upload but does nothing about many small files accumulating. A user could create N packs and upload tens of thousands of small avatars, eventually pushing the shared disk to capacity.

Adds a cumulative-bytes gate before each upload:

- `getUserAvatarsUsage(userId)` walks the user's avatar directory recursively (each pack has its own subdir with thumbnail + original files) and sums file sizes. Tolerates ENOENT and stat/readdir races.
- Upload handler refuses with `413` if `currentUsage + req.file.size > quota`. Uses incoming buffer size as upper bound for the post-resize footprint — sharp generally shrinks, so this errs toward rejecting borderline uploads rather than letting the user creep past the cap.

Default quota: 50 MB, generous enough for 500+ post-resize avatars at sharp's `webp@quality:90` (typically 10–100 KB). Override via `AVATAR_USER_QUOTA_MB` env var.

**Not covered (deliberate scope limit; easy follow-ups if needed):**
- Pack `/clone` endpoint could still bypass by cloning a large pack to a new packId.
- No event logged on quota rejection (just the 413 response).

## 3. `chore`: add Node `engines` pin to backend/shared/frontend

Root `package.json` already declares `engines: { node: ">=22" }`, and `.nvmrc` pins to `22.14.0`. The three workspace packages had no `engines` field, so `npm install` in a workspace directly (rather than from root) skips the version check — easy to miss on first clone or in per-workspace CI installs. Adds the same constraint to each workspace.

## Scope / risk

Three commits, all backend-config-shaped. Backend `npm run build` passes each intermediate state. The test-user gate is a behavior change for anyone whose local dev relied on `NODE_ENV` being unset — they now need either `NODE_ENV=development` (the conventional value, which most dev setups already use) or the `ENABLE_TEST_USERS=true` opt-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)