### PR TITLE
fix: allow removing attachments while editing messages

### DIFF
--- a/deprecated-claude-app/backend/src/websocket/handler.ts
+++ b/deprecated-claude-app/backend/src/websocket/handler.ts
@@ -1846,6 +1846,17 @@ async function handleEdit(
     return;
   }
 
+  const attachments = message.attachments !== undefined
+    ? message.attachments.map(att => ({
+        fileName: att.fileName,
+        fileType: att.fileType,
+        content: att.content,
+        fileSize: att.fileSize ?? Math.round(att.content.replace(/=+$/, '').length * 3 / 4),
+        mimeType: att.mimeType,
+        encoding: att.encoding
+      }))
+    : branch.attachments;
+
   // Create new branch with edited content
   // The parent should be the same as the original branch's parent (the previous message)
   const updatedMessage = await db.addMessageBranch(
@@ -1857,7 +1868,7 @@ async function handleEdit(
     branch.parentBranchId, // Use the same parent as the original branch
     branch.model,
     branch.participantId, // Keep the same participant
-    undefined, // no attachments
+    attachments,
     ws.userId, // user who made the edit
     undefined, // hiddenFromAi
     false,     // preserveActiveBranch - select this new branch

--- a/deprecated-claude-app/frontend/src/components/CompositeMessageGroup.vue
+++ b/deprecated-claude-app/frontend/src/components/CompositeMessageGroup.vue
@@ -93,8 +93,8 @@
         :authenticity-status="getAuthenticityStatus(message)"
         @regenerate="(msgId: string, branchId: string) => emit('regenerate', msgId, branchId)"
         @stuck-clicked="() => emit('stuck-clicked')"
-        @edit="(msgId: string, branchId: string, content: string) => emit('edit', msgId, branchId, content)"
-        @edit-only="(msgId: string, branchId: string, content: string) => emit('edit-only', msgId, branchId, content)"
+        @edit="(msgId: string, branchId: string, content: string, attachments?: WsAttachment[]) => emit('edit', msgId, branchId, content, attachments)"
+        @edit-only="(msgId: string, branchId: string, content: string, attachments?: WsAttachment[]) => emit('edit-only', msgId, branchId, content, attachments)"
         @switch-branch="(msgId: string, branchId: string) => emit('switch-branch', msgId, branchId)"
         @delete="(msgId: string, branchId: string) => emit('delete', msgId, branchId)"
         @delete-all-branches="(msgId: string) => emit('delete-all-branches', msgId)"
@@ -120,7 +120,7 @@ import { marked } from 'marked';
 import DOMPurify from 'dompurify';
 import MessageComponent from './MessageComponent.vue';
 import AuthenticityIcon from './AuthenticityIcon.vue';
-import type { Message, Participant } from '@deprecated-claude/shared';
+import type { Message, Participant, WsAttachment } from '@deprecated-claude/shared';
 import { getAvatarUrl, getParticipantColor } from '@/utils/avatars';
 import { type AuthenticityStatus, getAuthenticityLevel } from '@/utils/authenticity';
 
@@ -140,8 +140,8 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   regenerate: [msgId: string, branchId: string];
-  edit: [msgId: string, branchId: string, content: string];
-  'edit-only': [msgId: string, branchId: string, content: string];
+  edit: [msgId: string, branchId: string, content: string, attachments?: WsAttachment[]];
+  'edit-only': [msgId: string, branchId: string, content: string, attachments?: WsAttachment[]];
   'switch-branch': [msgId: string, branchId: string];
   delete: [msgId: string, branchId: string];
   'delete-all-branches': [msgId: string];

--- a/deprecated-claude-app/frontend/src/components/MessageComponent.vue
+++ b/deprecated-claude-app/frontend/src/components/MessageComponent.vue
@@ -555,6 +555,26 @@
           </v-chip>
         </template>
       </div>
+
+      <div v-if="canEditAttachments" class="mt-2">
+        <input
+          ref="editFileInput"
+          type="file"
+          :accept="EDIT_ATTACHMENT_ACCEPT"
+          multiple
+          style="display: none"
+          @change="handleEditAttachmentSelect"
+        />
+        <v-btn
+          size="small"
+          variant="text"
+          color="primary"
+          prepend-icon="mdi-paperclip-plus"
+          @click="triggerEditAttachmentInput"
+        >
+          Add attachment
+        </v-btn>
+      </div>
       
       <div v-if="isEditing" class="d-flex gap-2 mt-2">
         <v-btn
@@ -956,6 +976,7 @@ const editContent = ref('');
 type EditableAttachment = Pick<Attachment, 'fileName' | 'fileType' | 'content'> & Partial<Pick<Attachment, 'id' | 'fileSize' | 'mimeType' | 'encoding'>>;
 const editAttachments = ref<EditableAttachment[]>([]);
 const editAttachmentsDirty = ref(false);
+const editFileInput = ref<HTMLInputElement | null>(null);
 const messageCard = ref<HTMLElement>();
 const showScrollToTop = ref(false);
 const isHovered = ref(false);
@@ -1052,7 +1073,7 @@ const currentBranch = computed(() => {
   return branch;
 });
 
-const canEditAttachments = computed(() => isEditing.value && !isPostHocEditing.value);
+const canEditAttachments = computed(() => currentBranch.value?.role === 'user' && isEditing.value && !isPostHocEditing.value);
 const displayedAttachments = computed(() => {
   if (canEditAttachments.value) {
     return editAttachments.value;
@@ -1580,6 +1601,120 @@ function attachmentsChanged(): boolean {
 function removeEditAttachment(index: number) {
   editAttachments.value.splice(index, 1);
   editAttachmentsDirty.value = true;
+}
+
+const EDIT_ATTACHMENT_ACCEPT = '.txt,.md,.csv,.json,.xml,.html,.css,.js,.ts,.py,.java,.cpp,.c,.h,.hpp,.jpg,.jpeg,.png,.gif,.webp,.svg,.pdf,application/pdf,.mp3,.wav,.flac,.ogg,.m4a,.aac,.mp4,.mov,.avi,.mkv,.webm';
+const EDIT_FILE_TYPES = {
+  image: ['jpg', 'jpeg', 'png', 'gif', 'webp', 'svg'],
+  pdf: ['pdf'],
+  audio: ['mp3', 'wav', 'flac', 'ogg', 'm4a', 'aac', 'webm'],
+  video: ['mp4', 'mov', 'avi', 'mkv', 'webm'],
+};
+const EDIT_TEXT_EXTENSIONS = ['txt', 'md', 'csv', 'json', 'xml', 'html', 'css', 'js', 'ts', 'py', 'java', 'cpp', 'c', 'h', 'hpp'];
+const EDIT_MIME_TYPES: Record<string, string> = {
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  png: 'image/png',
+  gif: 'image/gif',
+  webp: 'image/webp',
+  svg: 'image/svg+xml',
+  pdf: 'application/pdf',
+  mp3: 'audio/mpeg',
+  wav: 'audio/wav',
+  flac: 'audio/flac',
+  ogg: 'audio/ogg',
+  m4a: 'audio/mp4',
+  aac: 'audio/aac',
+  mp4: 'video/mp4',
+  mov: 'video/quicktime',
+  avi: 'video/x-msvideo',
+  mkv: 'video/x-matroska',
+  webm: 'video/webm',
+};
+
+function triggerEditAttachmentInput() {
+  editFileInput.value?.click();
+}
+
+function getEditFileCategory(extension: string): 'image' | 'pdf' | 'audio' | 'video' | 'text' {
+  if (EDIT_FILE_TYPES.image.includes(extension)) return 'image';
+  if (EDIT_FILE_TYPES.pdf.includes(extension)) return 'pdf';
+  if (EDIT_FILE_TYPES.audio.includes(extension)) return 'audio';
+  if (EDIT_FILE_TYPES.video.includes(extension)) return 'video';
+  return 'text';
+}
+
+function isSupportedEditAttachment(file: File, extension: string): boolean {
+  const supportedExtensions = [
+    ...EDIT_FILE_TYPES.image,
+    ...EDIT_FILE_TYPES.pdf,
+    ...EDIT_FILE_TYPES.audio,
+    ...EDIT_FILE_TYPES.video,
+    ...EDIT_TEXT_EXTENSIONS,
+  ];
+  return supportedExtensions.includes(extension) ||
+    file.type.startsWith('image/') ||
+    file.type.startsWith('audio/') ||
+    file.type.startsWith('video/') ||
+    file.type === 'application/pdf';
+}
+
+function getEditMimeType(extension: string, file: File): string {
+  return file.type || EDIT_MIME_TYPES[extension] || 'application/octet-stream';
+}
+
+async function handleEditAttachmentSelect(event: Event) {
+  const input = event.target as HTMLInputElement;
+  if (!input.files) return;
+
+  for (const file of Array.from(input.files)) {
+    const extensionFromName = file.name.split('.').pop()?.toLowerCase() || '';
+    const extensionFromMime = file.type.split('/')[1]?.toLowerCase() || '';
+    const fileExtension = extensionFromName || extensionFromMime || 'txt';
+
+    if (!isSupportedEditAttachment(file, fileExtension)) {
+      console.log(`Unsupported edit attachment type: ${file.name}`);
+      continue;
+    }
+
+    const category = getEditFileCategory(fileExtension);
+    const mimeType = getEditMimeType(fileExtension, file);
+    const isBinary = category !== 'text' || file.type.startsWith('image/') || file.type.startsWith('audio/') || file.type.startsWith('video/') || file.type === 'application/pdf';
+    const content = isBinary ? await readEditFileAsBase64(file) : await readEditFileAsText(file);
+
+    editAttachments.value.push({
+      fileName: file.name || `attachment-${Date.now()}.${fileExtension}`,
+      fileType: fileExtension,
+      mimeType,
+      fileSize: file.size,
+      content,
+      encoding: isBinary ? 'base64' : 'text',
+    });
+    editAttachmentsDirty.value = true;
+  }
+
+  input.value = '';
+}
+
+function readEditFileAsText(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = (e) => resolve(e.target?.result as string);
+    reader.onerror = reject;
+    reader.readAsText(file);
+  });
+}
+
+function readEditFileAsBase64(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      const result = e.target?.result as string;
+      resolve(result.split(',')[1] || '');
+    };
+    reader.onerror = reject;
+    reader.readAsDataURL(file);
+  });
 }
 
 function startEdit() {

--- a/deprecated-claude-app/frontend/src/components/MessageComponent.vue
+++ b/deprecated-claude-app/frontend/src/components/MessageComponent.vue
@@ -955,6 +955,7 @@ const isPostHocEditing = ref(false); // True when editing for post-hoc operation
 const editContent = ref('');
 type EditableAttachment = Pick<Attachment, 'fileName' | 'fileType' | 'content'> & Partial<Pick<Attachment, 'id' | 'fileSize' | 'mimeType' | 'encoding'>>;
 const editAttachments = ref<EditableAttachment[]>([]);
+const editAttachmentsDirty = ref(false);
 const messageCard = ref<HTMLElement>();
 const showScrollToTop = ref(false);
 const isHovered = ref(false);
@@ -1578,6 +1579,7 @@ function attachmentsChanged(): boolean {
 
 function removeEditAttachment(index: number) {
   editAttachments.value.splice(index, 1);
+  editAttachmentsDirty.value = true;
 }
 
 function startEdit() {
@@ -1585,6 +1587,7 @@ function startEdit() {
   isPostHocEditing.value = false;
   editContent.value = currentBranch.value.content;
   editAttachments.value = cloneEditableAttachments(currentBranch.value.attachments || []);
+  editAttachmentsDirty.value = false;
 }
 
 async function toggleBranchPrivacy() {
@@ -1609,6 +1612,7 @@ function startPostHocEdit() {
   isPostHocEditing.value = true;
   editContent.value = currentBranch.value.content;
   editAttachments.value = [];
+  editAttachmentsDirty.value = false;
 }
 
 function cancelEdit() {
@@ -1616,11 +1620,12 @@ function cancelEdit() {
   isPostHocEditing.value = false;
   editContent.value = '';
   editAttachments.value = [];
+  editAttachmentsDirty.value = false;
 }
 
 function saveEdit() {
   const contentChanged = editContent.value !== currentBranch.value.content;
-  const attachmentListChanged = !isPostHocEditing.value && attachmentsChanged();
+  const attachmentListChanged = !isPostHocEditing.value && (editAttachmentsDirty.value || attachmentsChanged());
   if (contentChanged || attachmentListChanged) {
     if (isPostHocEditing.value) {
       // Create a post-hoc edit operation (no regeneration)
@@ -1635,7 +1640,7 @@ function saveEdit() {
 
 function saveEditOnly() {
   const contentChanged = editContent.value !== currentBranch.value.content;
-  const attachmentListChanged = !isPostHocEditing.value && attachmentsChanged();
+  const attachmentListChanged = !isPostHocEditing.value && (editAttachmentsDirty.value || attachmentsChanged());
   if (contentChanged || attachmentListChanged) {
     // Edit and branch without triggering regeneration
     emit('edit-only', props.message.id, currentBranch.value.id, editContent.value, attachmentListChanged ? editAttachments.value : undefined);

--- a/deprecated-claude-app/frontend/src/components/MessageComponent.vue
+++ b/deprecated-claude-app/frontend/src/components/MessageComponent.vue
@@ -515,16 +515,29 @@
       </div>
       
       <!-- Attachments display (for user messages) -->
-      <div v-if="currentBranch.role === 'user' && currentBranch.attachments && currentBranch.attachments.length > 0" class="mt-2">
-        <template v-for="attachment in currentBranch.attachments" :key="attachment.id">
+      <div v-if="currentBranch.role === 'user' && displayedAttachments.length > 0" class="mt-2">
+        <template v-for="(attachment, index) in displayedAttachments" :key="attachment.id || `${attachment.fileName}-${index}`">
           <!-- Image attachments -->
           <div v-if="isImageAttachment(attachment)" class="mb-2">
-            <img 
-              :src="getImageSrc(attachment)"
-              :alt="attachment.fileName"
-              style="max-width: 300px; max-height: 300px; border-radius: 8px; cursor: pointer;"
-              @click="openImageInNewTab(attachment)"
-            />
+            <div class="attachment-image-wrapper">
+              <img 
+                :src="getImageSrc(attachment)"
+                :alt="attachment.fileName"
+                style="max-width: 300px; max-height: 300px; border-radius: 8px; cursor: pointer;"
+                @click="openImageInNewTab(attachment)"
+              />
+              <v-btn
+                v-if="canEditAttachments"
+                icon="mdi-close"
+                size="x-small"
+                color="error"
+                variant="flat"
+                density="compact"
+                class="attachment-remove-btn"
+                title="Remove attachment"
+                @click.stop="removeEditAttachment(index)"
+              />
+            </div>
             <div class="text-caption mt-1">{{ attachment.fileName }} ({{ formatFileSize(attachment.fileSize || 0) }})</div>
           </div>
           <!-- Text attachments -->
@@ -533,6 +546,8 @@
             class="mr-2 mb-1"
             size="small"
             color="grey-lighten-2"
+            :closable="canEditAttachments"
+            @click:close="removeEditAttachment(index)"
           >
             <v-icon start size="x-small">mdi-paperclip</v-icon>
             {{ attachment.fileName }}
@@ -884,7 +899,7 @@
 import { ref, computed, onMounted, onUnmounted, onUpdated, watch } from 'vue';
 import { marked } from 'marked';
 import DOMPurify from 'dompurify';
-import type { Message, Participant } from '@deprecated-claude/shared';
+import type { Attachment, Message, Participant } from '@deprecated-claude/shared';
 import { getModelColor } from '@/utils/modelColors';
 import { extractMath, restoreMath, KATEX_ALLOWED_TAGS, KATEX_ALLOWED_ATTRS } from '@/utils/latex';
 import '@/utils/dompurify-hooks'; // side-effect: hardens img tags via DOMPurify hook
@@ -916,8 +931,8 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   regenerate: [messageId: string, branchId: string];
-  edit: [messageId: string, branchId: string, content: string];
-  'edit-only': [messageId: string, branchId: string, content: string];  // Edit and branch without regeneration
+  edit: [messageId: string, branchId: string, content: string, attachments?: EditableAttachment[]];
+  'edit-only': [messageId: string, branchId: string, content: string, attachments?: EditableAttachment[]];  // Edit and branch without regeneration
   'switch-branch': [messageId: string, branchId: string];
   delete: [messageId: string, branchId: string];
   'delete-all-branches': [messageId: string];
@@ -938,6 +953,8 @@ const emit = defineEmits<{
 const isEditing = ref(false);
 const isPostHocEditing = ref(false); // True when editing for post-hoc operation (no regeneration)
 const editContent = ref('');
+type EditableAttachment = Pick<Attachment, 'fileName' | 'fileType' | 'content'> & Partial<Pick<Attachment, 'id' | 'fileSize' | 'mimeType' | 'encoding'>>;
+const editAttachments = ref<EditableAttachment[]>([]);
 const messageCard = ref<HTMLElement>();
 const showScrollToTop = ref(false);
 const isHovered = ref(false);
@@ -1032,6 +1049,14 @@ const branchIndex = computed(() => {
 const currentBranch = computed(() => {
   const branch = props.message.branches[branchIndex.value];
   return branch;
+});
+
+const canEditAttachments = computed(() => isEditing.value && !isPostHocEditing.value);
+const displayedAttachments = computed(() => {
+  if (canEditAttachments.value) {
+    return editAttachments.value;
+  }
+  return currentBranch.value?.attachments || [];
 });
 
 // Check if this message is a post-hoc operation
@@ -1522,10 +1547,44 @@ function escapeHtml(text: string): string {
   return div.innerHTML;
 }
 
+function cloneEditableAttachments(attachments: Attachment[] = []): EditableAttachment[] {
+  return attachments.map(att => ({
+    id: att.id,
+    fileName: att.fileName,
+    fileSize: att.fileSize,
+    fileType: att.fileType,
+    mimeType: att.mimeType,
+    content: att.content,
+    encoding: att.encoding
+  }));
+}
+
+function normalizedAttachmentList(attachments: EditableAttachment[]) {
+  return attachments.map(att => ({
+    id: att.id,
+    fileName: att.fileName,
+    fileSize: att.fileSize,
+    fileType: att.fileType,
+    mimeType: att.mimeType,
+    encoding: att.encoding,
+    content: att.content
+  }));
+}
+
+function attachmentsChanged(): boolean {
+  return JSON.stringify(normalizedAttachmentList(editAttachments.value)) !==
+    JSON.stringify(normalizedAttachmentList(cloneEditableAttachments(currentBranch.value.attachments || [])));
+}
+
+function removeEditAttachment(index: number) {
+  editAttachments.value.splice(index, 1);
+}
+
 function startEdit() {
   isEditing.value = true;
   isPostHocEditing.value = false;
   editContent.value = currentBranch.value.content;
+  editAttachments.value = cloneEditableAttachments(currentBranch.value.attachments || []);
 }
 
 async function toggleBranchPrivacy() {
@@ -1549,31 +1608,37 @@ function startPostHocEdit() {
   isEditing.value = true;
   isPostHocEditing.value = true;
   editContent.value = currentBranch.value.content;
+  editAttachments.value = [];
 }
 
 function cancelEdit() {
   isEditing.value = false;
   isPostHocEditing.value = false;
   editContent.value = '';
+  editAttachments.value = [];
 }
 
 function saveEdit() {
-  if (editContent.value !== currentBranch.value.content) {
+  const contentChanged = editContent.value !== currentBranch.value.content;
+  const attachmentListChanged = !isPostHocEditing.value && attachmentsChanged();
+  if (contentChanged || attachmentListChanged) {
     if (isPostHocEditing.value) {
       // Create a post-hoc edit operation (no regeneration)
       emit('post-hoc-edit-content', props.message.id, currentBranch.value.id, editContent.value);
     } else {
       // Regular edit that triggers regeneration
-      emit('edit', props.message.id, currentBranch.value.id, editContent.value);
+      emit('edit', props.message.id, currentBranch.value.id, editContent.value, attachmentListChanged ? editAttachments.value : undefined);
     }
   }
   cancelEdit();
 }
 
 function saveEditOnly() {
-  if (editContent.value !== currentBranch.value.content) {
+  const contentChanged = editContent.value !== currentBranch.value.content;
+  const attachmentListChanged = !isPostHocEditing.value && attachmentsChanged();
+  if (contentChanged || attachmentListChanged) {
     // Edit and branch without triggering regeneration
-    emit('edit-only', props.message.id, currentBranch.value.id, editContent.value);
+    emit('edit-only', props.message.id, currentBranch.value.id, editContent.value, attachmentListChanged ? editAttachments.value : undefined);
   }
   cancelEdit();
 }
@@ -2100,6 +2165,18 @@ watch(() => currentBranch.value.id, async () => {
   opacity: 0.6;
 }
 
+.attachment-image-wrapper {
+  position: relative;
+  display: inline-block;
+  max-width: 300px;
+}
+
+.attachment-remove-btn {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+}
+
 /* Messages affected by post-hoc edit operations */
 .post-hoc-edited {
   border-left: 3px solid rgb(var(--v-theme-info)) !important;
@@ -2515,4 +2592,3 @@ watch(() => currentBranch.value.id, async () => {
   transform: translate(2px, 2px);
 }
 </style>
-

--- a/deprecated-claude-app/frontend/src/store/index.ts
+++ b/deprecated-claude-app/frontend/src/store/index.ts
@@ -1,5 +1,5 @@
 import { reactive, inject, InjectionKey, App } from 'vue';
-import type { User, Conversation, Message, Model, OpenRouterModel, UserDefinedModel, CreateUserModel, UpdateUserModel, UserGrantSummary } from '@deprecated-claude/shared';
+import type { User, Conversation, Message, Model, OpenRouterModel, UserDefinedModel, CreateUserModel, UpdateUserModel, UserGrantSummary, WsAttachment } from '@deprecated-claude/shared';
 import { getValidatedModelDefaults } from '@deprecated-claude/shared';
 import { api } from '../services/api';
 import { WebSocketService } from '../services/websocket';
@@ -85,7 +85,7 @@ export interface Store {
   continueGeneration(responderId?: string, explicitParentBranchId?: string, samplingBranches?: number): Promise<void>;
   regenerateMessage(messageId: string, branchId: string, parentBranchId?: string, samplingBranches?: number): Promise<void>;
   abortGeneration(): void;
-  editMessage(messageId: string, branchId: string, content: string, responderId?: string, skipRegeneration?: boolean, samplingBranches?: number): Promise<void>;
+  editMessage(messageId: string, branchId: string, content: string, responderId?: string, skipRegeneration?: boolean, samplingBranches?: number, attachments?: WsAttachment[]): Promise<void>;
   switchBranch(messageId: string, branchId: string): void;
   switchBranchesBatch(switches: Array<{ messageId: string; branchId: string }>): void;
   deleteMessage(messageId: string, branchId: string): Promise<void>;
@@ -766,7 +766,7 @@ export function createStore(): {
       });
     },
     
-    async editMessage(messageId: string, branchId: string, content: string, responderId?: string, skipRegeneration?: boolean, samplingBranches?: number) {
+    async editMessage(messageId: string, branchId: string, content: string, responderId?: string, skipRegeneration?: boolean, samplingBranches?: number, attachments?: WsAttachment[]) {
       if (!state.currentConversation || !state.wsService) return;
       
       state.wsService.sendMessage({
@@ -777,7 +777,8 @@ export function createStore(): {
         content,
         responderId, // Pass the currently selected responder
         skipRegeneration, // If true, don't generate AI response after edit
-        samplingBranches // Number of parallel response branches to generate
+        samplingBranches, // Number of parallel response branches to generate
+        ...(attachments !== undefined ? { attachments } : {})
       } as any);
       
       // Update the conversation's updatedAt timestamp locally for immediate sorting

--- a/deprecated-claude-app/frontend/src/views/ConversationView.vue
+++ b/deprecated-claude-app/frontend/src/views/ConversationView.vue
@@ -1256,7 +1256,7 @@ import { useRoute, useRouter } from 'vue-router';
 import { isEqual } from 'lodash-es';
 import { useStore } from '@/store';
 import { api } from '@/services/api';
-import type { Conversation, Message, Participant, Model, Bookmark, Persona } from '@deprecated-claude/shared';
+import type { Conversation, Message, Participant, Model, Bookmark, Persona, WsAttachment } from '@deprecated-claude/shared';
 import { UpdateParticipantSchema, getValidatedModelDefaults } from '@deprecated-claude/shared';
 import CompositeMessageGroup from '@/components/CompositeMessageGroup.vue';
 import ImportDialogV2 from '@/components/ImportDialogV2.vue';
@@ -3290,7 +3290,7 @@ function dismissStuckDialog() {
   showStuckButton.value = false;
 }
 
-async function editMessage(messageId: string, branchId: string, content: string) {
+async function editMessage(messageId: string, branchId: string, content: string, attachments?: WsAttachment[]) {
   // Pass the currently selected responder for multi-participant mode
   let responderId: string | undefined;
   
@@ -3305,12 +3305,12 @@ async function editMessage(messageId: string, branchId: string, content: string)
     responderId = selectedResponder.value || undefined;
   }
   
-  await store.editMessage(messageId, branchId, content, responderId, false, samplingBranches.value);
+  await store.editMessage(messageId, branchId, content, responderId, false, samplingBranches.value, attachments);
 }
 
-async function editMessageOnly(messageId: string, branchId: string, content: string) {
+async function editMessageOnly(messageId: string, branchId: string, content: string, attachments?: WsAttachment[]) {
   // Edit and branch without triggering AI regeneration
-  await store.editMessage(messageId, branchId, content, undefined, true);
+  await store.editMessage(messageId, branchId, content, undefined, true, undefined, attachments);
 }
 
 function switchBranch(messageId: string, branchId: string) {

--- a/deprecated-claude-app/shared/src/types.ts
+++ b/deprecated-claude-app/shared/src/types.ts
@@ -429,6 +429,16 @@ export const AttachmentSchema = z.object({
 
 export type Attachment = z.infer<typeof AttachmentSchema>;
 
+const WsAttachmentSchema = z.object({
+  fileName: z.string(),
+  fileType: z.string(),
+  content: z.string(),
+  fileSize: z.number().optional(),
+  mimeType: z.string().optional(),
+  encoding: z.enum(['base64', 'text', 'url']).optional()
+});
+export type WsAttachment = z.infer<typeof WsAttachmentSchema>;
+
 // Bookmark types
 export const BookmarkSchema = z.object({
   id: z.string().uuid(),
@@ -628,11 +638,7 @@ export const WsMessageSchema = z.discriminatedUnion('type', [
     parentBranchId: z.string().uuid().optional(),
     participantId: z.string().uuid().optional(),
     responderId: z.string().uuid().optional(), // Which assistant should respond (if any)
-    attachments: z.array(z.object({
-      fileName: z.string(),
-      fileType: z.string(),
-      content: z.string()
-    })).optional(),
+    attachments: z.array(WsAttachmentSchema).optional(),
     hiddenFromAi: z.boolean().optional(), // If true, message is visible to humans but not included in AI context
     samplingBranches: z.number().min(1).max(10).optional() // Number of parallel response branches to generate
   }),
@@ -650,6 +656,7 @@ export const WsMessageSchema = z.discriminatedUnion('type', [
     messageId: z.string().uuid(),
     branchId: z.string().uuid(),
     content: z.string(),
+    attachments: z.array(WsAttachmentSchema).optional(), // Replacement attachments for the edited branch
     responderId: z.string().uuid().optional(), // Which assistant should respond after edit
     skipRegeneration: z.boolean().optional(), // If true, don't generate AI response after edit
     samplingBranches: z.number().min(1).max(10).optional() // Number of parallel response branches to generate


### PR DESCRIPTION
## Summary

Editing a user message now carries an explicit replacement attachment list, so users can remove an accidentally attached image/file while creating the edited branch.

## Why

The edit path previously created the new branch with `undefined` attachments. The UI also displayed existing attachments during edit mode but offered no way to remove them, so an accidental attachment was effectively stuck unless the whole message/branch was abandoned.

## Notes

Older clients still preserve the original branch attachments because the backend only replaces attachments when the edit message explicitly includes an `attachments` field. Sending `attachments: []` removes all attachments for the edited branch.

## Validation

- `npm run build`
