### PR TITLE
Render inline <thinking> tags equivalently to structured thinking blocks

### DIFF
--- a/deprecated-claude-app/frontend/src/components/MessageComponent.vue
+++ b/deprecated-claude-app/frontend/src/components/MessageComponent.vue
@@ -1338,17 +1338,43 @@ const hasNavigableBranches = computed(() => {
   return siblingBranches.value.length > 1;
 });
 
-// Extract thinking blocks from content blocks
+// Some routes (e.g. Anthropic models via OpenRouter when the reasoning
+// signature isn't propagated) emit thinking as literal <thinking>…</thinking>
+// inside delta.content rather than via structured reasoning fields. The right
+// fix is upstream, but in the meantime the UI lifts those tags out of the
+// body and surfaces them in the same thinking toggle as structured blocks.
+// Acts on the rendered branch's content only — stored data is untouched.
+const CLOSED_INLINE_THINKING = /<thinking>([\s\S]*?)<\/thinking>/gi;
+const TRAILING_OPEN_THINKING = /<thinking>([\s\S]*)$/i;
+
+function extractInlineThinking(text: string): { closed: string[]; partial?: string } {
+  if (!text) return { closed: [] };
+  const closed: string[] = [];
+  for (const m of text.matchAll(CLOSED_INLINE_THINKING)) {
+    const t = m[1].trim();
+    if (t) closed.push(t);
+  }
+  // After stripping closed pairs, a dangling open tag means streaming is
+  // mid-thought; surface what's been streamed so far in the panel too.
+  const withoutClosed = text.replace(CLOSED_INLINE_THINKING, '');
+  const dangling = withoutClosed.match(TRAILING_OPEN_THINKING);
+  const partial = dangling ? dangling[1].trim() : '';
+  return { closed, partial: partial.length > 0 ? partial : undefined };
+}
+
+// Extract thinking blocks from content blocks (and salvage inline tags)
 const thinkingBlocks = computed(() => {
   const branch = currentBranch.value;
-  if (!branch.contentBlocks || branch.contentBlocks.length === 0) {
-    return [];
-  }
-  
-  // Filter for thinking and redacted_thinking blocks
-  return branch.contentBlocks.filter((block: any) => 
+  const structured = (branch?.contentBlocks || []).filter((block: any) =>
     block.type === 'thinking' || block.type === 'redacted_thinking'
   );
+
+  const source = props.postHocAffected?.editedContent ?? branch?.content ?? '';
+  const { closed, partial } = extractInlineThinking(source);
+  const inline = closed.map(t => ({ type: 'thinking' as const, thinking: t }));
+  if (partial) inline.push({ type: 'thinking' as const, thinking: partial });
+
+  return [...structured, ...inline];
 });
 
 // Extract generated image blocks from content blocks
@@ -1420,6 +1446,17 @@ const renderedContent = computed(() => {
     inlineCode.push(match);
     return `__INLINE_CODE_${index}__`;
   });
+
+  // Lift inline <thinking>…</thinking> tags out of the displayed body. Their
+  // contents are surfaced separately via the thinking toggle (see
+  // thinkingBlocks). This runs AFTER code-block / inline-code protection so
+  // literal <thinking> inside ``` fences or backticks is preserved verbatim.
+  // Also drops a dangling unclosed <thinking> at the very end of the stream
+  // so it doesn't flash as raw text mid-response.
+  content = content
+    .replace(CLOSED_INLINE_THINKING, '')
+    .replace(TRAILING_OPEN_THINKING, '')
+    .replace(/\n{3,}/g, '\n\n');
 
   // Extract LaTeX math regions BEFORE markdown runs. CommonMark backslash
   // escapes (\(, \), \[, \]) would otherwise be consumed by marked.parse,

--- a/deprecated-claude-app/frontend/src/components/MessageComponent.vue
+++ b/deprecated-claude-app/frontend/src/components/MessageComponent.vue
@@ -1347,19 +1347,69 @@ const hasNavigableBranches = computed(() => {
 const CLOSED_INLINE_THINKING = /<thinking>([\s\S]*?)<\/thinking>/gi;
 const TRAILING_OPEN_THINKING = /<thinking>([\s\S]*)$/i;
 
-function extractInlineThinking(text: string): { closed: string[]; partial?: string } {
-  if (!text) return { closed: [] };
+function getMarkdownCodeRanges(text: string): Array<[number, number]> {
+  const ranges: Array<[number, number]> = [];
+
+  for (const match of text.matchAll(/```[\s\S]*?```/g)) {
+    const start = match.index ?? 0;
+    ranges.push([start, start + match[0].length]);
+  }
+
+  for (const match of text.matchAll(/`[^`\n]+`/g)) {
+    const start = match.index ?? 0;
+    const end = start + match[0].length;
+    if (!ranges.some(([rangeStart, rangeEnd]) => start >= rangeStart && start < rangeEnd)) {
+      ranges.push([start, end]);
+    }
+  }
+
+  return ranges.sort(([a], [b]) => a - b);
+}
+
+function isInsideRange(index: number, ranges: Array<[number, number]>): boolean {
+  return ranges.some(([start, end]) => index >= start && index < end);
+}
+
+function extractInlineThinking(text: string): { closed: string[]; partial?: string; visibleContent: string; hasInlineThinking: boolean } {
+  if (!text) return { closed: [], visibleContent: '', hasInlineThinking: false };
   const closed: string[] = [];
+  const ranges = getMarkdownCodeRanges(text);
+  const visibleParts: string[] = [];
+  let lastIndex = 0;
+  let hasInlineThinking = false;
+
   for (const m of text.matchAll(CLOSED_INLINE_THINKING)) {
+    const start = m.index ?? 0;
+    if (isInsideRange(start, ranges)) continue;
+
     const t = m[1].trim();
     if (t) closed.push(t);
+    visibleParts.push(text.slice(lastIndex, start));
+    lastIndex = start + m[0].length;
+    hasInlineThinking = true;
   }
+
+  visibleParts.push(text.slice(lastIndex));
+
   // After stripping closed pairs, a dangling open tag means streaming is
   // mid-thought; surface what's been streamed so far in the panel too.
-  const withoutClosed = text.replace(CLOSED_INLINE_THINKING, '');
-  const dangling = withoutClosed.match(TRAILING_OPEN_THINKING);
+  let visibleContent = visibleParts.join('');
+  const dangling = visibleContent.match(TRAILING_OPEN_THINKING);
+  const danglingStart = dangling?.index ?? -1;
+  const visibleRanges = dangling ? getMarkdownCodeRanges(visibleContent) : [];
+  const hasDanglingThinking = dangling && !isInsideRange(danglingStart, visibleRanges);
+  if (hasDanglingThinking) {
+    visibleContent = visibleContent.slice(0, danglingStart);
+    hasInlineThinking = true;
+  }
   const partial = dangling ? dangling[1].trim() : '';
-  return { closed, partial: partial.length > 0 ? partial : undefined };
+
+  return {
+    closed,
+    partial: hasDanglingThinking && partial.length > 0 ? partial : undefined,
+    visibleContent: visibleContent.replace(/\n{3,}/g, '\n\n'),
+    hasInlineThinking
+  };
 }
 
 // Extract thinking blocks from content blocks (and salvage inline tags)
@@ -1397,9 +1447,10 @@ const thinkingPanelOpen = ref<number | undefined>(undefined);
 
 // Check if thinking is currently streaming (has thinking blocks, is streaming, no content yet)
 const isThinkingStreaming = computed(() => {
+  const visibleContent = extractInlineThinking(currentBranch.value.content || '').visibleContent.trim();
   const streaming = props.isStreaming && 
          thinkingBlocks.value.length > 0 && 
-         !currentBranch.value.content?.trim();
+         !visibleContent;
   return streaming;
 });
 
@@ -1424,6 +1475,12 @@ watch(isThinkingStreaming, (streaming, oldStreaming) => {
 const renderedContent = computed(() => {
   // Use edited content if this message has a post-hoc edit applied
   let content = props.postHocAffected?.editedContent ?? currentBranch.value.content;
+
+  // Lift inline <thinking>…</thinking> tags out of the displayed body. Their
+  // contents are surfaced separately via the thinking toggle (see
+  // thinkingBlocks). The extractor ignores tags inside Markdown code fences and
+  // inline backtick spans, so examples remain visible as literal code.
+  content = extractInlineThinking(content).visibleContent;
   
   // Preserve leading/trailing whitespace by converting to non-breaking spaces
   const leadingSpaces = content.match(/^(\s+)/)?.[1] || '';
@@ -1446,17 +1503,6 @@ const renderedContent = computed(() => {
     inlineCode.push(match);
     return `__INLINE_CODE_${index}__`;
   });
-
-  // Lift inline <thinking>…</thinking> tags out of the displayed body. Their
-  // contents are surfaced separately via the thinking toggle (see
-  // thinkingBlocks). This runs AFTER code-block / inline-code protection so
-  // literal <thinking> inside ``` fences or backticks is preserved verbatim.
-  // Also drops a dangling unclosed <thinking> at the very end of the stream
-  // so it doesn't flash as raw text mid-response.
-  content = content
-    .replace(CLOSED_INLINE_THINKING, '')
-    .replace(TRAILING_OPEN_THINKING, '')
-    .replace(/\n{3,}/g, '\n\n');
 
   // Extract LaTeX math regions BEFORE markdown runs. CommonMark backslash
   // escapes (\(, \), \[, \]) would otherwise be consumed by marked.parse,
@@ -2552,4 +2598,3 @@ watch(() => currentBranch.value.id, async () => {
   transform: translate(2px, 2px);
 }
 </style>
-


### PR DESCRIPTION
## Why

Some assistant responses emit thinking as literal \`<thinking>…</thinking>\` inside \`delta.content\` rather than via structured reasoning fields (notably Anthropic models via OpenRouter when the reasoning signature isn't propagated end-to-end). The trace gets persisted as flat body text and renders inline with the response, instead of in the collapsible thinking toggle that structured \`contentBlocks\` of type \`thinking\` would feed.

## What

Purely presentational, single file (\`MessageComponent.vue\`, +44/-7). Stored data untouched.

- \`thinkingBlocks\` computed now also salvages inline \`<thinking>…</thinking>\` from the rendered branch's content and merges them in alongside structured blocks, so they show in the same toggle.
- \`renderedContent\` strips closed inline thinking tags from the displayed body. Runs **after** the existing code-block / inline-code protection, so literal tags inside \`\`\` fences or backticks are preserved verbatim.
- Handles a dangling unclosed \`<thinking>\` at the very end of a streaming response (lifts the in-flight content into the panel, strips it from the body) so it doesn't flash as raw text mid-stream.

## Scope

Deliberately downstream. The upstream causes — reasoning-signature loss on inbound from \`delta.reasoning\` array items, and outbound serialization of unsigned thinking as literal tagged text (which trains models to mimic the format) — are real and still warranted, but tracked separately. This patch makes the UI look right regardless of which shape the trace was stored in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)