### PR TITLE
fix: shorten scroll-to-bottom repin window

### DIFF
--- a/deprecated-claude-app/frontend/src/views/ConversationView.vue
+++ b/deprecated-claude-app/frontend/src/views/ConversationView.vue
@@ -2903,7 +2903,7 @@ function scrollToBottom(smooth: boolean = false) {
   // which left the view stranded near the top. Instead keep re-pinning to
   // the bottom each tick and only conclude once the height has been stable
   // for several consecutive ticks (or a bounded number of attempts).
-  const MAX_ATTEMPTS = 40;       // ~2s ceiling for very heavy conversations
+  const MAX_ATTEMPTS = 20;       // ~1s ceiling for very heavy conversations
   const STABLE_TICKS_REQUIRED = 3; // ~150ms of quiet before we call it done
   const finish = () => {
     setTimeout(() => { isProgrammaticScroll.value = false; }, 100);


### PR DESCRIPTION
## Summary
- reduce the scroll-to-bottom re-pin ceiling from about 2 seconds to about 1 second

## Why
The longer re-pin window can bounce the user back to the bottom after they manually scroll up shortly after load. A shorter window preserves the late-render protection while reducing the time during which the view fights manual scrolling.

## Validation
- `npm run build -w frontend`
