### PR TITLE
feat(backend): cursor-paginated message API + server-side branch activation (PR #64 foundation)

### DIFF
--- a/deprecated-claude-app/backend/src/database/index.ts
+++ b/deprecated-claude-app/backend/src/database/index.ts
@@ -5537,6 +5537,407 @@ export class Database {
     return this.personaStore.getSharesForPersona(personaId);
   }
 
+
+  // ============================================================
+  // Pagination + server-side branch activation (PR #64 foundation)
+  // ============================================================
+  // The methods below back the cursor-paginated conversation API
+  // and the server-side branch-activation endpoint. Originally
+  // designed by @nickmahdavi in PR #64 as the backend foundation
+  // for virtual-scrolling the conversation view; ported here so
+  // the API design lands independently of the (still-evolving)
+  // frontend virtualization UI.
+  //
+  //   - activateBranch / switchBranchesBatch: move the
+  //     active-branch flip from frontend to backend, returning
+  //     the {messageId, branchId} pairs that changed.
+  //   - getConversationMessageBranchPage: cursor-based paginated
+  //     message fetch (older / newer direction).
+  //   - getVisibleMessagePath / computeVisiblePath: derive the
+  //     currently-visible message path from the tree.
+  //   - getConversationBookmarksEnriched: bookmark fetch with
+  //     denormalized preview/participant/model/role fields, for
+  //     sidebar rendering without a full message-tree load.
+
+  async activateBranch(messageId: string, branchId: string, conversationId: string, conversationOwnerUserId: string, isDetached: boolean = false): Promise<Map<string, string> | undefined> {
+    await this.loadUser(conversationOwnerUserId);
+    await this.loadConversation(conversationId, conversationOwnerUserId);
+
+    const allMessages = await this.getConversationMessages(conversationId, conversationOwnerUserId);
+
+    // Build path from target branch back to root
+    const pathToRoot: { messageId: string, branchId: string }[] = [];
+
+    // Find the target branch and trace back to root
+    let currentBranchId: string | undefined = branchId;
+
+    while (currentBranchId && currentBranchId !== 'root') {
+      // Find the message containing this branch
+      const message = allMessages.find(m =>
+        m.branches.some(b => b.id === currentBranchId)
+      );
+
+      if (!message) {
+        console.error(`[activateBranch] Could not find message for branch: ${currentBranchId}`);
+        console.log('[activateBranch] messages:', allMessages.map(m => ({
+          id: m.id,
+          branchIds: m.branches.map(b => b.id)
+        })));
+        break;
+      }
+
+      // Add to path
+      pathToRoot.unshift({ messageId: message.id, branchId: currentBranchId });
+
+      // Find the branch to get its parent
+      const branch = message.branches.find(b => b.id === currentBranchId);
+      if (!branch) break;
+
+      currentBranchId = branch.parentBranchId;
+    }
+
+    console.log('[activateBranch] Path to switch:', pathToRoot);
+
+    // Collect all branches that need switching
+    const branchesToSwitch = pathToRoot.filter(({ messageId: msgId, branchId: brId }) => {
+      const message = allMessages.find(m => m.id === msgId);
+      return message && message.activeBranchId !== brId;
+    });
+
+    // Use batch switch for much faster navigation
+    console.log(`[activateBranch] Batch switching ${branchesToSwitch.length} branches`);
+    const changedMessages = this.switchBranchesBatch(allMessages, branchesToSwitch);
+    if (changedMessages) {
+      for (const [msgId, branchId] of changedMessages) {
+        if (isDetached) {
+          await this.setUserDetachedBranch(conversationId, conversationOwnerUserId, msgId, branchId);
+        } else {
+          await this.setActiveBranch(msgId, conversationId, conversationOwnerUserId, branchId);
+        }
+      }
+
+      await this.markBranchesAsRead(conversationId, conversationOwnerUserId, Array.from(changedMessages.values()));
+    }
+    return changedMessages;
+  }
+
+  private switchBranchesBatch(allMessages: Message[], switches: Array<{ messageId: string; branchId: string }>): Map<string, string> | undefined {
+    if (switches.length === 0) return;
+
+    // Apply all local state changes first
+    const changedMessages = new Map<string, string>(); // messageId -> branchId
+    for (const { messageId, branchId } of switches) {
+      const message = allMessages.find(m => m.id === messageId);
+      if (!message) continue;
+
+      if (message.activeBranchId !== branchId) {
+        message.activeBranchId = branchId;
+        changedMessages.set(messageId, branchId);
+      }
+    }
+
+    if (changedMessages.size === 0) {
+      return;
+    }
+
+    // Build the branch path by following parentBranchId from the deepest switch
+    const sortedMessages = this.sortMessagesByTreeOrder(allMessages);
+
+    // Find the deepest switch (furthest from root in the tree)
+    let deepestSwitchBranchId: string | null = null;
+    let deepestIndex = -1;
+
+    for (const { messageId, branchId } of switches) {
+      const idx = sortedMessages.findIndex(m => m.id === messageId);
+      if (idx > deepestIndex) {
+        deepestIndex = idx;
+        deepestSwitchBranchId = branchId;
+      }
+    }
+
+    if (!deepestSwitchBranchId) {
+      console.warn('[switchBranchesBatch] No valid switch found');
+      return;
+    }
+
+    // Build the branch path by tracing from deepest switch back to root
+    const branchPath: string[] = [];
+    let traceBranchId: string | null = deepestSwitchBranchId;
+
+    while (traceBranchId && traceBranchId !== 'root') {
+      branchPath.unshift(traceBranchId);
+      const msg = allMessages.find(m => m.branches.some(b => b.id === traceBranchId));
+      if (!msg) break;
+      const branch = msg.branches.find(b => b.id === traceBranchId);
+      traceBranchId = branch?.parentBranchId || null;
+    }
+
+    // Update all messages to follow this path
+    for (const msg of sortedMessages) {
+      for (const branch of msg.branches) {
+        const parentInPath = branch.parentBranchId === 'root' || branchPath.includes(branch.parentBranchId!);
+        const branchInPath = branchPath.includes(branch.id);
+
+        if (parentInPath && branchInPath && msg.activeBranchId !== branch.id) {
+          msg.activeBranchId = branch.id;
+          changedMessages.set(msg.id, branch.id);
+          break;
+        }
+      }
+    }
+
+    return changedMessages;
+  }
+
+  /**
+   * Build a parent→children adjacency map for efficient tree traversal.
+   * Returns Map<parentBranchId, Array<{messageId, branch}>>
+   */
+
+  async getConversationMessageBranchPage(conversationId: string, conversationOwnerUserId: string, limit: number, cursorMessageId?: string, direction: 'older' | 'newer' = 'older', requestingUserId?: string): Promise<Message[]> {
+    await this.loadUser(conversationOwnerUserId);
+    await this.loadConversation(conversationId, conversationOwnerUserId);
+    const messageIds = this.conversationMessages.get(conversationId) || [];
+
+    const message = await (async () => {
+      if (cursorMessageId) {
+        return await this.tryLoadAndVerifyMessage(cursorMessageId, conversationId, conversationOwnerUserId);
+      } else {
+        // TODO Duplicate logic from above; refactor
+        const viewerId = requestingUserId || conversationOwnerUserId;
+        const messages = this.sortMessagesByTreeOrder(messageIds
+          .map(id => this.messages.get(id))
+          .filter((msg): msg is Message => msg !== undefined)
+          .map(msg => {
+            // Filter out branches that are private to other users
+            const visibleBranches = msg.branches.filter(
+              b => !b.privateToUserId || b.privateToUserId === viewerId
+            );
+            return { ...msg, branches: visibleBranches };
+          })
+          .filter(msg => msg.branches.length > 0)); // Remove messages with no visible branches
+        
+        // Get the latest message in the conversation tree
+        let message = messages[0];
+        for (const currentMessage of messages) {
+          const currentBranch = currentMessage.branches.find(b => b.id === currentMessage.activeBranchId);
+          if (currentBranch?.parentBranchId === message.activeBranchId) {
+            message = currentMessage;
+          }
+        }
+        return message;
+      }
+    })();
+
+    if (!message) {
+      console.warn(`[getConversationMessageBranchPage] Message not found: ${cursorMessageId} in conversation ${conversationId}`);
+      return [];
+    }
+    
+    const viewerId = requestingUserId || conversationOwnerUserId;
+
+    if (direction === 'older') {
+      const branchesMap: Map<string, string> = new Map(
+        messageIds.flatMap(msgId => {
+          const msg = this.messages.get(msgId);
+          if (!msg) return [];
+          const visibleBranches = msg.branches.filter(
+            b => !b.privateToUserId || b.privateToUserId === viewerId
+          );
+          return visibleBranches.map(b => [b.id, msgId] as const)
+        })
+      );
+
+      const page: Message[] = [];
+      let nextMessage: Message | undefined = message;
+
+      for (let i = 0; i < limit && nextMessage; i++) {
+        page.push(nextMessage);
+
+        const activeBranch = nextMessage.branches.find(b => b.id === nextMessage!.activeBranchId);
+        if (!activeBranch || !activeBranch.parentBranchId || activeBranch.parentBranchId === 'root') break;
+
+        let nextMessageId = branchesMap.get(activeBranch.parentBranchId);
+        if (!nextMessageId) break;
+
+        nextMessage = this.messages.get(nextMessageId);
+      }
+
+      return page.reverse();
+
+    } else {
+      // This is also some duplicate logic (from alignActiveBranchPath)
+      // some of the states here are potentially illegal? (multiple children messages)
+      // Right now, we only get the first
+      const parentToChildren: Map<string, Message> = new Map();
+      for (const messageId of messageIds) {
+        const msg = this.messages.get(messageId);
+        if (!msg) continue;
+        const visibleBranches = msg.branches.filter(b => !b.privateToUserId || b.privateToUserId === viewerId);
+        if (visibleBranches.length === 0) continue;
+        for (const branch of visibleBranches) {
+          const parentId = branch.parentBranchId || 'root';
+          if (!parentToChildren.has(parentId)) {
+            parentToChildren.set(parentId, msg);
+            break; // Only map first found child
+          }
+        }
+      }
+
+      const page: Message[] = [];
+
+      const cursorBranch = message.branches.find(b => b.id === message.activeBranchId);
+      let nextMessage: Message | undefined = cursorBranch ? parentToChildren.get(cursorBranch.id) : undefined;
+
+      for (let i = 0; i < limit && nextMessage; i++) {
+        page.push(nextMessage);
+
+        const activeBranch = nextMessage.branches.find(b => b.id === nextMessage!.activeBranchId);
+        if (!activeBranch) break;
+
+        let nextMessageCandidate = parentToChildren.get(activeBranch.id);
+        if (!nextMessageCandidate) break;
+
+        nextMessage = nextMessageCandidate;
+      }
+
+      return page;
+    }
+  }
+
+  async getVisibleMessagePath(conversationId: string, conversationOwnerUserId: string, requestingUserId?: string): Promise<Message[]> {
+    const allMessages = await this.getConversationMessages(conversationId, conversationOwnerUserId, requestingUserId);
+    return this.computeVisiblePath(allMessages);
+  }
+
+  private computeVisiblePath(allMessages: Message[]): Message[] {
+    if (allMessages.length === 0) return [];
+
+    const sortedMessages = this.sortMessagesByTreeOrder(allMessages);
+
+    const rootMessages = sortedMessages.filter(msg => {
+      const activeBranch = msg.branches.find(b => b.id === msg.activeBranchId);
+      return activeBranch && (!activeBranch.parentBranchId || activeBranch.parentBranchId === 'root');
+    });
+
+    let canonicalRootId: string | null = null;
+    if (rootMessages.length > 1) {
+      const parentToChildren = new Map<string, Message[]>();
+      for (const msg of sortedMessages) {
+        for (const branch of msg.branches) {
+          const parentId = branch.parentBranchId || 'root';
+          if (!parentToChildren.has(parentId)) {
+            parentToChildren.set(parentId, []);
+          }
+          parentToChildren.get(parentId)!.push(msg);
+        }
+      }
+
+      const findLatestInSubtree = (root: Message): number => {
+        let latest = 0;
+        const visited = new Set<string>();
+
+        const visit = (msg: Message) => {
+          if (visited.has(msg.id)) return;
+          visited.add(msg.id);
+
+          for (const branch of msg.branches) {
+            if (branch.createdAt) {
+              const time = new Date(branch.createdAt).getTime();
+              if (time > latest) latest = time;
+            }
+            const children = parentToChildren.get(branch.id) || [];
+            for (const child of children) visit(child);
+          }
+        };
+
+        visit(root);
+        return latest;
+      };
+
+      let latestTime = 0;
+      for (const root of rootMessages) {
+        const rootTime = findLatestInSubtree(root);
+        if (rootTime > latestTime) {
+          latestTime = rootTime;
+          canonicalRootId = root.id;
+        }
+      }
+    } else if (rootMessages.length === 1) {
+      canonicalRootId = rootMessages[0].id;
+    }
+
+    const visibleMessages: Message[] = [];
+    const branchPath: string[] = [];
+
+    for (const message of sortedMessages) {
+      const activeBranch = message.branches.find(b => b.id === message.activeBranchId);
+
+      if (!activeBranch) {
+        continue;
+      }
+
+      if (!activeBranch.parentBranchId || activeBranch.parentBranchId === 'root') {
+        if (branchPath.length === 0 && (!canonicalRootId || message.id === canonicalRootId)) {
+          visibleMessages.push(message);
+          branchPath.push(activeBranch.id);
+        }
+        continue;
+      }
+
+      if (branchPath.includes(activeBranch.parentBranchId)) {
+        visibleMessages.push(message);
+        const parentIndex = branchPath.indexOf(activeBranch.parentBranchId);
+        branchPath.length = parentIndex + 1;
+        branchPath.push(activeBranch.id);
+      }
+    }
+
+    return visibleMessages;
+  }
+
+  async getConversationBookmarksEnriched(conversationId: string, userId: string): Promise<import('@deprecated-claude/shared').EnrichedBookmark[]> {
+    const bookmarks = await this.getConversationBookmarks(conversationId);
+    const participants = await this.getConversationParticipants(conversationId, userId);
+    const participantMap = new Map(participants.map(p => [p.id, p]));
+
+    const enriched: import('@deprecated-claude/shared').EnrichedBookmark[] = [];
+
+    for (const bookmark of bookmarks) {
+      const message = await this.getMessage(bookmark.messageId, conversationId, userId);
+      if (!message) continue;
+
+      const branch = message.branches.find(b => b.id === bookmark.branchId);
+      if (!branch) continue;
+
+      const content = branch.content || '';
+      const preview = content.slice(0, 250) + (content.length > 250 ? '...' : '');
+
+      let participantName = branch.role === 'user' ? 'User' : 'Assistant';
+      let model: string | null = branch.model || null;
+
+      if (branch.participantId) {
+        const participant = participantMap.get(branch.participantId);
+        if (participant) {
+          participantName = participant.name || (participant.type === 'user' ? 'User' : 'Assistant');
+          if (participant.type === 'assistant' && participant.model) {
+            model = participant.model;
+          }
+        }
+      }
+
+      enriched.push({
+        ...bookmark,
+        preview,
+        participantName,
+        model,
+        role: branch.role
+      });
+    }
+
+    return enriched;
+  }
+
   // Close database connection
   async close(): Promise<void> {
     await this.eventStore.close();

--- a/deprecated-claude-app/backend/src/database/index.ts
+++ b/deprecated-claude-app/backend/src/database/index.ts
@@ -5697,6 +5697,20 @@ export class Database {
   async getConversationMessageBranchPage(conversationId: string, conversationOwnerUserId: string, limit: number, cursorMessageId?: string, direction: 'older' | 'newer' = 'older', requestingUserId?: string): Promise<Message[]> {
     await this.loadUser(conversationOwnerUserId);
     await this.loadConversation(conversationId, conversationOwnerUserId);
+
+    // Backward-compatibility fallback: with no cursor and no limit, the
+    // contract of the route this backs (`GET /:id/messages`) is "return
+    // all messages across all branches" — that's what the previous
+    // `getConversationMessages` returned and what `store.allMessages`
+    // depends on for `switchBranch` to find off-active-path messages.
+    // Greptile #118 caught the regression: the cursor walk below only
+    // visits the active branch path, so branch-switching UI breaks for
+    // any conversation that has ever branched. Skip the walk in the
+    // unpaginated case.
+    if (!cursorMessageId && !Number.isFinite(limit)) {
+      return await this.getConversationMessages(conversationId, conversationOwnerUserId, requestingUserId);
+    }
+
     const messageIds = this.conversationMessages.get(conversationId) || [];
 
     const message = await (async () => {
@@ -5749,7 +5763,25 @@ export class Database {
       );
 
       const page: Message[] = [];
+
+      // When a cursor is provided, the cursor message itself is the
+      // boundary — exclude it from the page (the `newer` branch below
+      // already does this by starting from `parentToChildren.get(...)`
+      // i.e. the cursor's child). Without this, paginating backward
+      // would return the cursor message twice: once as the last item of
+      // the previous page and again as the first item of the next page.
+      // Greptile #118 catch. When no cursor is provided, `message` is
+      // the latest message in the tree and should be included as the
+      // first item of the initial page.
       let nextMessage: Message | undefined = message;
+      if (cursorMessageId) {
+        const cursorActiveBranch = message.branches.find(b => b.id === message.activeBranchId);
+        const parentMessageId = cursorActiveBranch?.parentBranchId
+          && cursorActiveBranch.parentBranchId !== 'root'
+          ? branchesMap.get(cursorActiveBranch.parentBranchId)
+          : undefined;
+        nextMessage = parentMessageId ? this.messages.get(parentMessageId) : undefined;
+      }
 
       for (let i = 0; i < limit && nextMessage; i++) {
         page.push(nextMessage);

--- a/deprecated-claude-app/backend/src/routes/bookmarks.ts
+++ b/deprecated-claude-app/backend/src/routes/bookmarks.ts
@@ -79,7 +79,10 @@ export function createBookmarksRouter(db: Database): Router {
     }
   });
 
-  // Get all bookmarks for a conversation
+  // Get all bookmarks for a conversation (enriched with preview/participant/
+  // model/role for sidebar rendering without loading the full message tree —
+  // see EnrichedBookmark in shared/types.ts. The response shape is a
+  // superset of the prior Bookmark[] so older clients still parse correctly.
   router.get('/conversation/:conversationId', authenticateToken, async (req: AuthRequest, res) => {
     try {
       const { conversationId } = req.params;
@@ -94,10 +97,38 @@ export function createBookmarksRouter(db: Database): Router {
         return res.status(404).json({ error: 'Conversation not found' });
       }
 
-      const bookmarks = await db.getConversationBookmarks(conversationId);
+      const bookmarks = await db.getConversationBookmarksEnriched(conversationId, req.userId);
       res.json(bookmarks);
     } catch (error) {
       console.error('Error fetching bookmarks:', error);
+      res.status(500).json({ error: 'Failed to fetch bookmarks' });
+    }
+  });
+
+  // Get bookmarks restricted to the currently-visible message path (i.e.
+  // bookmarks anchored to branches that are on the active conversation
+  // path). Used by clients that want to render only the bookmarks
+  // reachable from the current view rather than all branches' bookmarks.
+  router.get('/conversation/:conversationId/active-path', authenticateToken, async (req: AuthRequest, res) => {
+    try {
+      const { conversationId } = req.params;
+
+      if (!req.userId) {
+        return res.status(401).json({ error: 'Unauthorized' });
+      }
+
+      const conversation = await db.getConversation(conversationId, req.userId);
+      if (!conversation || conversation.userId !== req.userId) {
+        return res.status(404).json({ error: 'Conversation not found' });
+      }
+
+      const allBookmarks = await db.getConversationBookmarksEnriched(conversationId, req.userId);
+      const visibleMessages = await db.getVisibleMessagePath(conversationId, req.userId);
+      const visibleBranchIds = new Set(visibleMessages.map(m => m.activeBranchId));
+
+      res.json(allBookmarks.filter(b => visibleBranchIds.has(b.branchId)));
+    } catch (error) {
+      console.error('Error fetching active-path bookmarks:', error);
       res.status(500).json({ error: 'Failed to fetch bookmarks' });
     }
   });

--- a/deprecated-claude-app/backend/src/routes/conversations.ts
+++ b/deprecated-claude-app/backend/src/routes/conversations.ts
@@ -374,9 +374,27 @@ export function conversationRouter(db: Database): Router {
         return res.status(404).json({ error: 'Conversation not found' });
       }
 
+      // Pagination params (PR #64 foundation): if `cursor` is unset the
+      // call falls back to "return everything" via `limit = Infinity`,
+      // matching the pre-pagination contract for backward compatibility
+      // with clients that don't speak the cursor API yet.
+      const cursor = req.query.cursor as string | undefined;
+      const direction = req.query.direction === 'newer' ? 'newer' : 'older';
+      const limit = req.query.limit ? parseInt(req.query.limit as string, 10) : Infinity;
+      if (req.query.limit && (!Number.isFinite(limit) || limit < 1)) {
+        return res.status(400).json({ error: 'limit must be a positive integer' });
+      }
+
       // Note: Access control is handled in getConversation
       // Pass requesting user to filter private branches
-      const messages = await db.getConversationMessages(req.params.id, conversation.userId, req.userId);
+      const messages = await db.getConversationMessageBranchPage(
+        req.params.id,
+        conversation.userId,
+        limit,
+        cursor,
+        direction,
+        req.userId,
+      );
 
       // Prepare messages for client: strip debug data, convert old images to blob refs
       // Pass db and userId so conversions can be persisted (avoiding duplicate blobs after restart)
@@ -385,6 +403,47 @@ export function conversationRouter(db: Database): Router {
       res.json(preparedMessages);
     } catch (error) {
       console.error('Get messages error:', error);
+      res.status(500).json({ error: 'Internal server error' });
+    }
+  });
+
+  // POST /api/conversations/:id/activate-branch — server-side branch
+  // activation. Returns the {messageId, branchId} pairs that changed as a
+  // side effect (e.g. switching a deep branch may cascade up through
+  // parents). Lets clients flip the active branch without needing the
+  // full message tree loaded — the foundation move for the paginated /
+  // virtualized conversation view.
+  router.post('/:id/activate-branch', async (req: AuthRequest, res) => {
+    try {
+      if (!req.userId) {
+        return res.status(401).json({ error: 'Unauthorized' });
+      }
+
+      const { messageId, branchId, isDetached } = req.body;
+      if (!messageId || !branchId) {
+        return res.status(400).json({ error: 'messageId and branchId are required' });
+      }
+
+      const conversation = await db.getConversation(req.params.id, req.userId);
+      if (!conversation || conversation.userId !== req.userId) {
+        return res.status(404).json({ error: 'Conversation not found' });
+      }
+
+      const changedBranches = await db.activateBranch(
+        messageId,
+        branchId,
+        conversation.id,
+        conversation.userId,
+        isDetached,
+      );
+      res.json({
+        success: true,
+        changedBranches: changedBranches
+          ? Array.from(changedBranches.entries()).map(([messageId, branchId]) => ({ messageId, branchId }))
+          : [],
+      });
+    } catch (error) {
+      console.error('Activate branch error:', error);
       res.status(500).json({ error: 'Internal server error' });
     }
   });

--- a/deprecated-claude-app/backend/src/routes/conversations.ts
+++ b/deprecated-claude-app/backend/src/routes/conversations.ts
@@ -380,8 +380,11 @@ export function conversationRouter(db: Database): Router {
       // with clients that don't speak the cursor API yet.
       const cursor = req.query.cursor as string | undefined;
       const direction = req.query.direction === 'newer' ? 'newer' : 'older';
-      const limit = req.query.limit ? parseInt(req.query.limit as string, 10) : Infinity;
-      if (req.query.limit && (!Number.isFinite(limit) || limit < 1)) {
+      // Use Number() rather than parseInt — parseInt silently accepts
+      // mixed strings (`?limit=5abc` → 5), Number() rejects them as NaN.
+      // Greptile #118 catch.
+      const limit = req.query.limit ? Number(req.query.limit) : Infinity;
+      if (req.query.limit && (!Number.isInteger(limit) || limit < 1)) {
         return res.status(400).json({ error: 'limit must be a positive integer' });
       }
 

--- a/deprecated-claude-app/shared/src/types.ts
+++ b/deprecated-claude-app/shared/src/types.ts
@@ -441,6 +441,22 @@ export const BookmarkSchema = z.object({
 
 export type Bookmark = z.infer<typeof BookmarkSchema>;
 
+// Bookmark with denormalized fields needed for sidebar/jump-list rendering
+// without fetching the underlying message. `preview` is a short excerpt of
+// the bookmarked branch's content; `participantName`, `model`, and `role`
+// describe the message the bookmark anchors. Returned by
+// `Database.getConversationBookmarksEnriched` — useful when the client
+// doesn't have the full message tree loaded (e.g. paginated/virtualized
+// conversation views).
+export const EnrichedBookmarkSchema = BookmarkSchema.extend({
+  preview: z.string(),
+  participantName: z.string(),
+  model: z.string().nullable(),
+  role: z.enum(['user', 'assistant', 'system'])
+});
+
+export type EnrichedBookmark = z.infer<typeof EnrichedBookmarkSchema>;
+
 // Content block types for messages
 export const TextContentBlockSchema = z.object({
   type: z.literal('text'),


### PR DESCRIPTION
Extracts the **backend foundation** from [@nickmahdavi's PR #64](https://github.com/anima-research/animachat/pull/64) — cursor-based pagination, server-side branch activation, enriched bookmarks — and lands it independently of the (still-evolving) frontend virtual-scrolling UI in #64.

## Why split it this way

PR #64 has been open since Feb 2026 with the author's own to-do list flagging known broken state ("Tree view is broken", "Scroller height is broken", "Fix potential race conditions", "Hunt down persistence bugs"). Four months of main-flux on top of that. The full PR isn't merge-ready as-is.

But the **API design is sound**, and the foundation pieces are independently useful:
- Any future client (current frontend, the eventual virtual-scroll UI, a third-party API user) can start using the cursor-paginated `/messages` endpoint immediately
- Server-side branch activation (`/activate-branch`) removes a layer of frontend complexity for any client, not just virtualized ones
- Enriched bookmarks unblock sidebar/jump-list rendering scenarios that don't want to load the full message tree

Splitting lets us **ship the foundation now** and address the harder UI work (broken tree view, scroller height, race conditions) in a follow-up that lands on top of a known-good API.

## What this PR includes

**`shared/types.ts`:** `EnrichedBookmarkSchema` + `EnrichedBookmark` type — bookmark with denormalized `preview`, `participantName`, `model`, `role`.

**`backend/src/database/index.ts`** (+401 lines, end of class):
- `activateBranch(messageId, branchId, conversationId, ownerUserId, isDetached)` — flip the active branch server-side; returns `Map<messageId, branchId>` of pairs that changed (parent-cascade aware).
- `switchBranchesBatch(allMessages, switches)` (private helper) — applies a batch of branch switches in a single pass.
- `getConversationMessageBranchPage(conversationId, ownerUserId, limit, cursor?, direction='older', requestingUserId?)` — cursor-based pagination.
- `getVisibleMessagePath(conversationId, ownerUserId, requestingUserId?)` — returns the currently-visible message path through active branches.
- `computeVisiblePath(allMessages)` (private helper) — tree → visible path.
- `getConversationBookmarksEnriched(conversationId, userId)` — bookmarks with denormalized rendering fields.

**`backend/src/routes/conversations.ts`:**
- `GET /:id/messages` now accepts `?cursor=`, `?direction=`, `?limit=`. Unset = backward-compatible \"return all\" (limit defaults to Infinity). Invalid `limit` rejected with 400.
- `POST /:id/activate-branch` — new endpoint.

**`backend/src/routes/bookmarks.ts`:**
- `GET /conversation/:conversationId` upgraded to return enriched shape (superset of prior `Bookmark[]`; older clients still parse correctly).
- `GET /conversation/:conversationId/active-path` — new endpoint, filters bookmarks to those anchored on the currently-visible branch path.

## What this PR deliberately excludes from #64

- **`shared/types.ts` deletions.** PR #64 removed `personaContext`, `pseudoPrefillMode`, `pseudoPrefillFilename`, and `pseudo-prefill` from `ConversationModeEnum`. Those fields are now load-bearing in main — `personaContext` alone has 10+ active call sites in `handler.ts`. Bringing those deletions would be a feature regression of the persona system.
- **`package.json` re-introducing root-level runtime deps** (`compression`, `multer`, `@types/*`, `vue-virtual-scroller`). Would regress P4-6 and wipe the root `engines` block that PR #110 made the per-workspace versions match.
- **All frontend changes** (ConversationView.vue, store/index.ts, virtual scrolling implementation). The author's to-do list flags multiple broken-state items; landing those needs a substantive rebase + reimplementation pass on top of this foundation.

## One implementation detail worth noting

`tryLoadAndVerifyMessage` (a private helper PR #64 depended on) **already exists in current main** with an identical implementation — someone (probably Antra) added it independently since Feb. Verified via `diff`; skipped re-adding to avoid duplicate declaration. The methods this PR adds all reference the existing `tryLoadAndVerifyMessage` cleanly.

## Verification

- `npm run build -w shared` passes
- `npm run build -w backend` passes (with all 6 new methods + route changes)
- No conflicts with current main (cut from latest)
- No changes to shared/types beyond the additive `EnrichedBookmarkSchema`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
