### PR TITLE
fix(pricing): Opus 4.8 pricing + make admin config.json pricing actually gate-check

### DIFF
--- a/deprecated-claude-app/backend/src/services/enhanced-inference.ts
+++ b/deprecated-claude-app/backend/src/services/enhanced-inference.ts
@@ -78,6 +78,7 @@ type CostBreakdown = {
 
 const INPUT_PRICING_PER_MILLION: Record<string, number> = {
   // Claude 4.x models (2025) - by providerModelId
+  'claude-opus-4-8': 5.00,
   'claude-opus-4-7': 5.00,
   'claude-opus-4-6': 5.00,
   'claude-sonnet-4-6': 3.00,
@@ -98,6 +99,7 @@ const INPUT_PRICING_PER_MILLION: Record<string, number> = {
   'claude-3-haiku-20240307': 0.25,
   
   // Shorthand model IDs (for backwards compatibility / fallback)
+  'claude-opus-4.8': 5.00,
   'claude-opus-4.7': 5.00,
   'claude-opus-4.6': 5.00,
   'claude-sonnet-4.6': 3.00,
@@ -171,6 +173,7 @@ const INPUT_PRICING_PER_MILLION: Record<string, number> = {
 
 const OUTPUT_PRICING_PER_MILLION: Record<string, number> = {
   // Claude 4.x models (2025) - by providerModelId
+  'claude-opus-4-8': 25.00,
   'claude-opus-4-7': 25.00,
   'claude-opus-4-6': 25.00,
   'claude-sonnet-4-6': 15.00,
@@ -191,6 +194,7 @@ const OUTPUT_PRICING_PER_MILLION: Record<string, number> = {
   'claude-3-haiku-20240307': 1.25,
   
   // Shorthand model IDs (for backwards compatibility / fallback)
+  'claude-opus-4.8': 25.00,
   'claude-opus-4.7': 25.00,
   'claude-opus-4.6': 25.00,
   'claude-sonnet-4.6': 15.00,

--- a/deprecated-claude-app/backend/src/services/enhanced-inference.ts
+++ b/deprecated-claude-app/backend/src/services/enhanced-inference.ts
@@ -322,11 +322,53 @@ function hypotheticalNoCacheCost(
  * @param db Database instance for admin-configured pricing lookup
  * @returns { valid: true } if pricing is available, or { valid: false, error: string } if not
  */
+/**
+ * Look up admin-configured pricing from the loaded config (providers[].modelCosts).
+ *
+ * Shared source of truth for BOTH the pre-inference validation gate
+ * (validatePricingAvailable) and the per-token price getters
+ * (getInputPricePerToken / getOutputPricePerToken). Previously the validation
+ * gate called a `db.getAdminPricingConfig()` that was never implemented, so
+ * admin-config pricing was silently ignored at validation time and every model
+ * was forced to have an entry in the hardcoded table — even when config.json
+ * already priced it. This function closes that gap.
+ */
+export async function getConfigPricingFromLoader(
+  provider: string,
+  modelId: string,
+  providerModelId?: string
+): Promise<{ input: number; output: number } | null> {
+  try {
+    const configLoader = ConfigLoader.getInstance();
+    const config = await configLoader.loadConfig();
+    const profiles = config.providers[provider as keyof typeof config.providers];
+    if (!profiles || profiles.length === 0) return null;
+    for (const profile of profiles) {
+      if (profile.modelCosts) {
+        // Match by providerModelId first, then modelId.
+        const modelCost = profile.modelCosts.find(mc =>
+          mc.modelId === providerModelId || mc.modelId === modelId
+        );
+        if (modelCost) {
+          return {
+            input: modelCost.providerCost.inputTokensPerMillion,
+            output: modelCost.providerCost.outputTokensPerMillion
+          };
+        }
+      }
+    }
+    return null;
+  } catch (error) {
+    console.warn('[Pricing] Error loading config pricing:', error);
+    return null;
+  }
+}
+
 export async function validatePricingAvailable(
   model: Model,
   db?: { getAdminPricingConfig?: (provider: string, modelId: string, providerModelId?: string) => Promise<any> }
 ): Promise<{ valid: true } | { valid: false; error: string }> {
-  
+
   // 0. User-defined custom models bypass pricing validation
   // These are models the user created themselves (identified by UUID ID or customEndpoint)
   // The user accepts responsibility for costs when they set up their own API key/endpoint
@@ -336,8 +378,15 @@ export async function validatePricingAvailable(
     console.log(`[Pricing] Bypassing validation for user-defined model "${model.displayName}" (${model.id})`);
     return { valid: true };
   }
-  
-  // 1. Check admin-configured pricing
+
+  // 1. Check admin-configured pricing (config.json providers[].modelCosts).
+  //    This is the SAME source the cost calculation uses, so a model priced in
+  //    config.json validates here without also needing a hardcoded-table entry.
+  const adminConfigPricing = await getConfigPricingFromLoader(model.provider, model.id, model.providerModelId);
+  if (adminConfigPricing) {
+    return { valid: true };
+  }
+  // Legacy hook: honour an explicit db.getAdminPricingConfig if a caller provides one.
   if (db?.getAdminPricingConfig) {
     try {
       const configPricing = await db.getAdminPricingConfig(model.provider, model.id, model.providerModelId);
@@ -348,7 +397,7 @@ export async function validatePricingAvailable(
       // Admin config lookup failed, continue to other sources
     }
   }
-  
+
   // 2. For OpenRouter models, check the cached pricing
   if (model.provider === 'openrouter' && model.providerModelId) {
     let orPricing = getOpenRouterPricing(model.providerModelId);
@@ -926,36 +975,9 @@ export class EnhancedInferenceService {
    * Returns { input, output } in per-million rates, or null if not configured.
    */
   private async getConfigPricing(provider: string, modelId: string, providerModelId?: string): Promise<{ input: number; output: number } | null> {
-    try {
-      const configLoader = ConfigLoader.getInstance();
-      const config = await configLoader.loadConfig();
-      const profiles = config.providers[provider as keyof typeof config.providers];
-      
-      if (!profiles || profiles.length === 0) return null;
-      
-      // Search through all profiles for this provider
-      for (const profile of profiles) {
-        if (profile.modelCosts) {
-          // Try to find by providerModelId first, then modelId
-          const modelCost = profile.modelCosts.find(mc => 
-            mc.modelId === providerModelId || mc.modelId === modelId
-          );
-          
-          if (modelCost) {
-            console.log(`[Pricing] Using admin config pricing for ${modelId} (provider: ${provider})`);
-            return {
-              input: modelCost.providerCost.inputTokensPerMillion,
-              output: modelCost.providerCost.outputTokensPerMillion
-            };
-          }
-        }
-      }
-      
-      return null;
-    } catch (error) {
-      console.warn('[Pricing] Error loading config pricing:', error);
-      return null;
-    }
+    // Delegate to the shared module-level helper so the validation gate
+    // (validatePricingAvailable) and the cost calculation use one source of truth.
+    return getConfigPricingFromLoader(provider, modelId, providerModelId);
   }
 
   private async getInputPricePerToken(model: Model): Promise<number> {


### PR DESCRIPTION
## Context

Opus 4.8 was added to production (models.json + config.json modelCosts) but
first use threw **"Pricing not configured for this model"** — despite the
model showing pricing in `/api/public/models`. This PR fixes the immediate
cause and the underlying bug behind it.

## Commit 1 — add `claude-opus-4-8` to the hardcoded pricing table

Mirrors the 4.7 entries (`$5/M` input, `$25/M` output), both `claude-opus-4-8`
(providerModelId) and `claude-opus-4.8` (dotted) forms. Anthropic-direct only.

Already hot-patched on the deployed prod-a + prod-b `enhanced-inference.js`;
this keeps it through the next deploy.

## Commit 2 — make admin `config.json` pricing work at the validation gate (the real bug)

`validatePricingAvailable()` gated on `db.getAdminPricingConfig(...)` — **a
method that is never defined anywhere in the codebase.** So admin-configured
pricing (`config.json` → `providers[].modelCosts`) was silently ignored at
validation time, and every model was forced to also exist in the hardcoded
`INPUT/OUTPUT_PRICING_PER_MILLION` tables or fail with "Pricing not configured."

That's *why* adding 4.8 via config wasn't sufficient.

Fix: the cost-calculation path already reads config pricing via
`getConfigPricing` (`ConfigLoader` → `providers[].modelCosts`). Extracted that
into a shared module-level `getConfigPricingFromLoader()` and call it from
`validatePricingAvailable()` step 1, so the **validation gate and the cost
calculation share one source of truth.** The legacy `db.getAdminPricingConfig`
hook is retained (honoured if ever provided) but no longer required.

After this, a model priced in `config.json` validates without also needing a
hardcoded-table entry. The hardcoded fallback remains for models priced only
there; the 4.8 table entry from commit 1 stays as belt-and-suspenders.

## Production status

- prod-a (`arc.animalabs.ai`) and prod-b (`arc.at-hub.com`) already have the
  commit-1 hot-patch live; Opus 4.8 works on both right now.
- Commit 2 is **not** hot-deployed — it lands on the next deploy. No urgency
  since the table workaround is in place.

## Test plan
- [x] Backend typechecks (only pre-existing `express-rate-limit` error, unrelated)
- [x] `validatePricingAvailable(claude-opus-4.8)` → `{valid:true}` on both prod instances (verified live)
- [ ] After deploy: add a model via `config.json` modelCosts *only* (no hardcoded entry) and confirm it validates — proves commit 2

## Follow-up (not here)
The decision of whether `db.getAdminPricingConfig` should exist at all (vs. the
module helper) could be tidied — the hook is now vestigial. Left in for safety.

🤖 Generated with [Claude Code](https://claude.com/claude-code)