### PR TITLE
fix(persistence): prevent torn-write JSONL corruption in conversation logs

### DIFF
--- a/deprecated-claude-app/backend/scripts/verify-append-concurrency.ts
+++ b/deprecated-claude-app/backend/scripts/verify-append-concurrency.ts
@@ -1,0 +1,99 @@
+/**
+ * Regression check for issue #121 — JSONL corruption where two events written
+ * far apart in time were fused onto one unparseable line.
+ *
+ * Root cause: a *torn write* — an event written without its terminating newline
+ * (process interrupted mid-write / partial write error) — so the NEXT append
+ * concatenated onto the partial line, fusing two events.
+ *
+ * This verifies the newline-boundary guard: after a torn prior write, the next
+ * appended event must land on its OWN clean, parseable line (the torn fragment
+ * isolated, not fused). Also sanity-checks concurrent appends.
+ *
+ * Run:  npx tsx scripts/verify-append-concurrency.ts   (exits non-zero on failure)
+ */
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { EventStore } from '../src/database/persistence.js';
+
+function ev(seq: number, content = `event-${seq}`) {
+  return { timestamp: new Date(0), type: 'message_content_updated', data: { seq, content } };
+}
+
+async function testTornWriteRecovery(): Promise<boolean> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'evstore-torn-'));
+  const file = path.join(dir, 'events.jsonl');
+
+  // 1) Two clean events via the normal path.
+  let store = new EventStore(dir, 'events.jsonl');
+  await store.init();
+  await store.appendEvent(ev(1));
+  await store.appendEvent(ev(2));
+  await store.close();
+
+  // 2) Simulate a torn write: a partial event line with NO terminating newline,
+  //    exactly like a process killed mid-write.
+  await fs.appendFile(file, '{"timestamp":"1970-01-01T00:00:00.000Z","type":"message_branch_added","data":{"seq":3,"partial":true');
+
+  // 3) Next process/append: a fresh EventStore (init heals) then append event 4.
+  store = new EventStore(dir, 'events.jsonl');
+  await store.init();
+  await store.appendEvent(ev(4, 'after-the-torn-write'));
+  await store.close();
+
+  // 4) Validate: event 4 must be parseable on its own line; it must NOT be fused
+  //    with the torn fragment. The torn fragment is allowed to be its own
+  //    (single) unparseable line — the loader skips exactly that one.
+  const raw = await fs.readFile(file, 'utf-8');
+  const lines = raw.split('\n').filter((l) => l.trim());
+  let parseable = 0, corrupt = 0, found4 = false, fused = false;
+  for (const l of lines) {
+    try {
+      const e = JSON.parse(l);
+      parseable++;
+      if (e.data?.seq === 4 && e.data?.content === 'after-the-torn-write') found4 = true;
+    } catch {
+      corrupt++;
+      // If the unparseable line also contains event 4's marker, it was fused.
+      if (l.includes('after-the-torn-write')) fused = true;
+    }
+  }
+  await fs.rm(dir, { recursive: true, force: true });
+
+  const ok = found4 && !fused && corrupt === 1 && parseable === 3; // events 1,2,4 parse; fragment 3 isolated
+  console.log(`[torn-write] parseable=${parseable} corrupt=${corrupt} event4Recovered=${found4} fused=${fused}`);
+  if (!ok) console.error('[torn-write] FAIL: torn write fused with the next event (issue #121 regression)');
+  return ok;
+}
+
+async function testConcurrentAppends(): Promise<boolean> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'evstore-conc-'));
+  const store = new EventStore(dir, 'events.jsonl');
+  await store.init();
+  const N = 300;
+  await Promise.all(
+    Array.from({ length: N }, (_, i) =>
+      store.appendEvent(ev(i, 'x'.repeat(2000 + (i % 40) * 300)))
+    )
+  );
+  await store.close();
+  const raw = await fs.readFile(path.join(dir, 'events.jsonl'), 'utf-8');
+  const lines = raw.split('\n').filter((l) => l.trim());
+  let corrupt = 0; const seqs = new Set<number>();
+  for (const l of lines) { try { seqs.add(JSON.parse(l).data.seq); } catch { corrupt++; } }
+  await fs.rm(dir, { recursive: true, force: true });
+  const ok = corrupt === 0 && lines.length === N && seqs.size === N;
+  console.log(`[concurrent] appended=${N} lines=${lines.length} unique=${seqs.size} corrupt=${corrupt}`);
+  if (!ok) console.error('[concurrent] FAIL');
+  return ok;
+}
+
+async function main() {
+  const a = await testTornWriteRecovery();
+  const b = await testConcurrentAppends();
+  if (a && b) { console.log('PASS'); process.exit(0); }
+  process.exit(1);
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/deprecated-claude-app/backend/src/database/persistence.ts
+++ b/deprecated-claude-app/backend/src/database/persistence.ts
@@ -12,7 +12,21 @@ export interface Event {
 export class EventStore {
   private filePath: string;
   private writeStream: fs.FileHandle | null = null;
-  
+  // Serializes appends to this file (defense in depth): chaining each write
+  // after the previous prevents concurrent appendEvent() calls from interleaving
+  // write()/sync() syscalls. See issue #121.
+  private writeChain: Promise<void> = Promise.resolve();
+  // PRIMARY corruption guard. The observed corruption (issue #121) fused events
+  // written HOURS or DAYS apart onto a single line — i.e. not a concurrency
+  // race but a *torn write*: an event was written without its terminating
+  // newline (process interrupted mid-write, or a partial write error), so the
+  // next append concatenated onto that partial line. When the current file does
+  // not end in a newline, a prior write was torn; we prepend a newline to the
+  // next event so it starts on its own clean line, bounding the damage to the
+  // single torn fragment (which the skip-tolerant loader drops) instead of
+  // fusing two events into one unparseable line.
+  private needsLeadingNewline: boolean = false;
+
   constructor(dataDir: string = './data', fileName: string = 'events.jsonl') {
     this.filePath = path.join(dataDir, fileName);
   }
@@ -21,7 +35,28 @@ export class EventStore {
     // Ensure data directory exists
     const dir = path.dirname(this.filePath);
     await fs.mkdir(dir, { recursive: true });
-    
+
+    // Detect a torn prior write left by a previous process: if the file is
+    // non-empty and doesn't end in a newline, the last write didn't finish.
+    // Flag it so the next append starts on a fresh line instead of fusing.
+    try {
+      const st = await fs.stat(this.filePath);
+      if (st.size > 0) {
+        const fh = await fs.open(this.filePath, 'r');
+        try {
+          const buf = Buffer.alloc(1);
+          await fh.read(buf, 0, 1, st.size - 1);
+          if (buf[0] !== 0x0a /* '\n' */) {
+            this.needsLeadingNewline = true;
+          }
+        } finally {
+          await fh.close();
+        }
+      }
+    } catch (err: any) {
+      if (err?.code !== 'ENOENT') throw err;
+    }
+
     // Open file for appending
     this.writeStream = await fs.open(this.filePath, 'a');
   }
@@ -30,14 +65,33 @@ export class EventStore {
     if (!this.writeStream) {
       throw new Error('Event store not initialized');
     }
-    
+
     const line = JSON.stringify({
       ...event,
       timestamp: event.timestamp.toISOString()
     }) + '\n';
-    
-    await this.writeStream.write(line);
-    await this.writeStream.sync(); // Ensure it's written to disk
+
+    // Append only after any in-flight write to the same file has completed
+    // (see `writeChain` above) so concurrent writers can't interleave a
+    // partial line. A single line per write, fully flushed, before the next.
+    const write = this.writeChain.then(async () => {
+      if (!this.writeStream) {
+        throw new Error('Event store closed before write completed');
+      }
+      // If a previous write was torn (file not newline-terminated), start this
+      // event on a clean line so we don't fuse onto the partial fragment.
+      const payload = (this.needsLeadingNewline ? '\n' : '') + line;
+      // Pessimistically assume torn until this write fully lands; cleared below.
+      this.needsLeadingNewline = true;
+      await this.writeStream.write(payload);
+      await this.writeStream.sync(); // Ensure it's written to disk
+      // Full line (terminated by '\n') is now on disk: boundary is clean.
+      this.needsLeadingNewline = false;
+    });
+    // Keep the chain alive even if this write rejects, so one failed write
+    // doesn't wedge every subsequent append. The caller still sees the error.
+    this.writeChain = write.catch(() => {});
+    return write;
   }
   
   async loadEvents(): Promise<Event[]> {
@@ -56,13 +110,16 @@ export class EventStore {
     // fs.readFile() fails for files larger than 2GB due to Node.js string size limits
     return new Promise((resolve, reject) => {
       const events: Event[] = [];
+      let lineNum = 0;
+      let skipped = 0;
       const stream = createReadStream(this.filePath, { encoding: 'utf-8' });
       const rl = createInterface({
         input: stream,
         crlfDelay: Infinity
       });
-      
+
       rl.on('line', (line) => {
+        lineNum++;
         if (line.trim()) {
           try {
             const event = JSON.parse(line);
@@ -71,12 +128,18 @@ export class EventStore {
               timestamp: new Date(event.timestamp)
             });
           } catch (parseError) {
-            console.warn(`[EventStore] Skipping malformed line: ${parseError}`);
+            skipped++;
+            // Include file + line so corruption is diagnosable from logs/metrics
+            // instead of surfacing only as a user-reported "lost data" report.
+            console.warn(`[EventStore] Skipping malformed line ${lineNum} in ${this.filePath}: ${parseError}`);
           }
         }
       });
-      
+
       rl.on('close', () => {
+        if (skipped > 0) {
+          console.error(`[EventStore] CORRUPTION: skipped ${skipped} malformed line(s) while loading ${this.filePath} — investigate (see issue #121)`);
+        }
         resolve(events);
       });
       
@@ -91,6 +154,14 @@ export class EventStore {
   }
   
   async close(): Promise<void> {
+    // Let any queued/in-flight writes drain before closing the handle, so an
+    // LRU eviction (BulkEventStore.purgeOldFileHandles) can't close the fd
+    // mid-write and lose or corrupt a pending event.
+    try {
+      await this.writeChain;
+    } catch {
+      /* a failed write must not block close */
+    }
     if (this.writeStream) {
       await this.writeStream.close();
       this.writeStream = null;


### PR DESCRIPTION
Fixes #121.

## Root cause (corrected from the issue's initial hypothesis)

#121 first guessed a concurrent-write race. It isn't: the fused events were written **hours-to-days apart** (`b8126e6b`: 19:28 + 22:20; `5d7c2d1d`: 05-23 + 05-25; `0850ad0c`: 12-15 + 12-18) — concurrency can't fuse events that far apart in time.

The real mechanism is a **torn write**: an event was written without its terminating newline (process interrupted mid-write, or a partial write error), leaving the log not newline-terminated. The **next** append then concatenated directly onto that partial line, fusing two events into one unparseable line.

## Fix (`EventStore` — covers the global log and every per-conversation log via `BulkEventStore`)

1. **Newline-boundary guard (primary).** `init()` reads the file's last byte; if it isn't `\n`, a prior write was torn, so the next append is prefixed with `\n`. `appendEvent` also sets the flag pessimistically before writing and clears it only after `write()`+`sync()` complete, catching in-process partial writes too. A torn write now damages only its own fragment (which the skip-tolerant loader already drops) instead of fusing onto the next event.
2. **Append serialization (defense in depth).** Each append chains after the previous so concurrent `appendEvent()` calls can't interleave syscalls; `close()` drains the chain before closing the fd so LRU eviction can't close mid-write.
3. **Observable corruption.** Loader skip-log now includes file + line number and emits a `CORRUPTION:` error with a count on close — so this shows up in logs/metrics instead of as a user "lost data" report (which is how #121 was found).

## Verification

`scripts/verify-append-concurrency.ts` (`npx tsx scripts/verify-append-concurrency.ts`):

| scenario | without fix | with fix |
|---|---|---|
| torn write then append | **FAIL** — `fused=true`, next event lost | **PASS** — fragment isolated, next event recovered |
| 300 concurrent large appends | pass | pass |

The torn-write case reproduces the exact #121 corruption on the old code and is resolved by this change. (No test runner on `main` yet — the suite in #112 is unmerged — so this is a standalone tsx script; fold it into the suite when that lands.)

## Test plan
- [x] `tsc --noEmit` clean (only the pre-existing `express-rate-limit` error)
- [x] verify script passes with fix, torn-write case fails without it
- [ ] deploy to staging, restart, confirm no `CORRUPTION:`/malformed warnings on load
- [ ] (prod) ships on next deploy — not hot-patched

## Incident context
3 conversations were corrupted (~0.18% of 1697) and have been repaired/salvaged out-of-band; this PR prevents recurrence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)