### PR TITLE
feat: add chapterx_prompt import format

### DIFF
--- a/deprecated-claude-app/backend/src/routes/import.ts
+++ b/deprecated-claude-app/backend/src/routes/import.ts
@@ -16,10 +16,38 @@ import {
   importClaudeArchive,
   previewClaudeArchive
 } from '../services/claudeArchiveImporter.js';
-import { 
-  ImportRequestSchema, 
-  ImportFormat
+import {
+  ImportRequestSchema,
+  ImportFormat,
+  Model
 } from '@deprecated-claude/shared';
+import { ModelLoader } from '../config/model-loader.js';
+
+/**
+ * Resolve a chapterx-emitted raw model identifier (e.g. "claude-opus-4-8")
+ * against Arc's model registry. Match attempts, in order:
+ *   1. exact match on `providerModelId`
+ *   2. exact match on `id` or `canonicalId`
+ *   3. normalized match (lowercase, dots→dashes) on any of the above
+ *
+ * Returns the canonical Arc model entry on match, or null on miss.
+ * UI uses the result to decide between "ready to import" and "please pick a model".
+ */
+function resolveChapterXModelId(rawId: string | undefined, models: Model[]): Model | null {
+  if (!rawId) return null;
+  const norm = (s: string) => s.toLowerCase().replace(/\./g, '-').replace(/_/g, '-');
+  const target = norm(rawId);
+  for (const m of models) {
+    if (m.providerModelId === rawId || m.id === rawId || (m as any).canonicalId === rawId) return m;
+  }
+  for (const m of models) {
+    if (norm(m.providerModelId) === target) return m;
+    if (norm(m.id) === target) return m;
+    const canonical = (m as any).canonicalId;
+    if (canonical && norm(canonical) === target) return m;
+  }
+  return null;
+}
 
 type ClaudeArchiveJobStatus = 'previewed' | 'running' | 'completed' | 'failed';
 
@@ -257,6 +285,26 @@ export function importRouter(db: Database): Router {
       const preview = await parser.parse(format as ImportFormat, content, {
         allowedParticipants: allowedParticipants as string[] | undefined
       });
+
+      // For chapterx_prompt, enrich metadata with a model-registry lookup so
+      // the UI can decide between "model resolved, ready to import" and
+      // "no match, please pick a model from the dropdown" without a second
+      // round trip. Strict lookup per the locked decision; no fuzzy fallback.
+      if (format === 'chapterx_prompt' && preview.metadata?.model?.raw) {
+        const modelLoader = ModelLoader.getInstance();
+        const models = await modelLoader.getAllModels(req.userId);
+        const resolved = resolveChapterXModelId(preview.metadata.model.raw, models);
+        preview.metadata.model = {
+          ...preview.metadata.model,
+          resolved: resolved ? {
+            matched: true,
+            id: resolved.id,
+            displayName: resolved.displayName,
+            provider: resolved.provider,
+          } : { matched: false }
+        };
+      }
+
       res.json(preview);
     } catch (error) {
       console.error('Import preview error:', error);
@@ -288,15 +336,49 @@ export function importRouter(db: Database): Router {
       });
       
       // Determine the model to use for the conversation
-      // Priority: 1. Explicit model in request, 2. First assistant from arc_chat participants, 3. Default
+      // Priority: 1. Explicit model in request, 2. First assistant from arc_chat participants,
+      //           3. Resolved chapterx model header, 4. Default
       let conversationModel = importRequest.model;
       if (!conversationModel && importRequest.format === 'arc_chat' && preview.metadata?.participants) {
         const firstAssistant = preview.metadata.participants.find((p: any) => p.type === 'assistant');
         conversationModel = firstAssistant?.model;
       }
-      // Fallback to a sensible default
+      if (importRequest.format === 'chapterx_prompt' && !conversationModel && preview.metadata?.model?.raw) {
+        const modelLoader = ModelLoader.getInstance();
+        const models = await modelLoader.getAllModels(req.userId);
+        const resolved = resolveChapterXModelId(preview.metadata.model.raw, models);
+        if (resolved) {
+          conversationModel = resolved.id;
+          console.log(`[chapterx_prompt] resolved model "${preview.metadata.model.raw}" -> "${resolved.id}"`);
+        }
+      }
+
+      // Strict-on-miss for chapterx_prompt: if neither the user nor the
+      // registry resolution produced a model, reject the import rather than
+      // silently importing under the global default. The UI is supposed to
+      // force a dropdown choice on miss; this is the defensive backstop.
+      if (importRequest.format === 'chapterx_prompt' && !conversationModel) {
+        return res.status(400).json({
+          error: `ChapterX import: model "${preview.metadata?.model?.raw ?? 'unknown'}" not in registry. Pick a model in the import dialog before retrying.`
+        });
+      }
+
+      // Fallback to a sensible default for non-chapterx formats
       conversationModel = conversationModel || 'anthropic/claude-sonnet-4-20250514';
-      
+
+      // Compute conversation-level contextManagement from chapterx rolling
+      // defaults so the imported conversation behaves like it did in chapterx
+      // (rolling window at roughly the current conversation size).
+      let conversationContextManagement: any = undefined;
+      if (importRequest.format === 'chapterx_prompt' && preview.metadata?.rollingDefaults) {
+        conversationContextManagement = {
+          strategy: 'rolling',
+          maxTokens: preview.metadata.rollingDefaults.maxTokens,
+          maxGraceTokens: preview.metadata.rollingDefaults.maxGraceTokens,
+        };
+        console.log(`[chapterx_prompt] applying rolling context: maxTokens=${conversationContextManagement.maxTokens}, grace=${conversationContextManagement.maxGraceTokens}`);
+      }
+
       // Create the conversation
       const conversation = await db.createConversation(
         req.userId,
@@ -304,7 +386,8 @@ export function importRouter(db: Database): Router {
         conversationModel,
         undefined, // System prompt will be set on participants
         undefined, // Settings will be set on participants
-        importRequest.conversationFormat
+        importRequest.conversationFormat,
+        conversationContextManagement
       );
 
       // Get default participants
@@ -403,12 +486,68 @@ export function importRouter(db: Database): Router {
         }
       }
 
+      // ChapterX-specific: apply source system prompt + sampling params to the
+      // source-side assistant participant ONLY. We resolve the target by name
+      // (parser metadata's `assistantName`) via `participantMap`, falling back
+      // to a unique-default lookup if mappings weren't provided. This avoids
+      // contaminating other assistant participants the user may have created
+      // through remapping or that exist as Arc defaults alongside the mapped
+      // chapterx assistant.
+      if (importRequest.format === 'chapterx_prompt' && preview.metadata) {
+        const importSystemPrompt = importRequest.importSystemPrompt !== false;
+        const sysPrompt: string | undefined = importSystemPrompt
+          ? preview.metadata.systemPrompt
+          : undefined;
+        const params = preview.metadata.params || {};
+        const targetAssistantName: string | undefined = preview.metadata.assistantName;
+
+        // Resolve the target participant id. Strategy:
+        //   1. If parser surfaced an assistantName AND mappings produced an
+        //      entry for it, use that (typical: UI sends mappings).
+        //   2. Else if there's exactly one assistant in the conversation,
+        //      that's unambiguously the target (typical: no mappings sent).
+        //   3. Else: ambiguous — skip with a warning so we don't apply
+        //      chapterx settings to the wrong participant.
+        const allParticipants = await db.getConversationParticipants(conversation.id, conversation.userId);
+        const assistantParticipants = allParticipants.filter((p: any) => p.type === 'assistant');
+
+        let targetId: string | undefined;
+        if (targetAssistantName && participantMap.has(targetAssistantName)) {
+          targetId = participantMap.get(targetAssistantName);
+        } else if (assistantParticipants.length === 1) {
+          targetId = assistantParticipants[0].id;
+        }
+
+        if (targetId) {
+          const ap = assistantParticipants.find((p: any) => p.id === targetId);
+          if (ap) {
+            const updates: any = {};
+            if (sysPrompt) updates.systemPrompt = sysPrompt;
+            const settingsUpdate: any = {};
+            if (typeof params.temperature === 'number') settingsUpdate.temperature = params.temperature;
+            if (typeof params.maxTokens === 'number') settingsUpdate.maxTokens = params.maxTokens;
+            if (Object.keys(settingsUpdate).length > 0) {
+              // updateParticipant merges top-level keys, but settings is itself
+              // an object on the participant — merge with existing settings so
+              // we don't blow away other keys.
+              updates.settings = { ...(ap.settings || {}), ...settingsUpdate };
+            }
+            if (Object.keys(updates).length > 0) {
+              await db.updateParticipant(ap.id, conversation.userId, updates);
+              console.log(`[chapterx_prompt] applied to assistant ${ap.id} (${ap.name}): ${Object.keys(updates).join(', ')}`);
+            }
+          }
+        } else {
+          console.log(`[chapterx_prompt] could not resolve unique target assistant (mapping miss + ${assistantParticipants.length} assistants); skipping system-prompt/settings application`);
+        }
+      }
+
       // Import messages with branch support
-      const messageIdMap = new Map<string, string>(); // originalUuid -> createdMessageId  
+      const messageIdMap = new Map<string, string>(); // originalUuid -> createdMessageId
       const branchIdMap = new Map<string, string>(); // originalUuid -> createdBranchId
       // Track messages by their parent and role to group branches correctly
       const messagesByParentAndRole = new Map<string, string>(); // "parentUuid:role" -> messageId
-      
+
       console.log(`Importing ${preview.messages.length} messages to conversation ${conversation.id}`);
       
       // Special handling for Arc Chat format - filter out orphaned messages, import all legitimate content

--- a/deprecated-claude-app/backend/src/services/importParser.ts
+++ b/deprecated-claude-app/backend/src/services/importParser.ts
@@ -5,8 +5,14 @@ import {
   RawMessageSchema 
 } from '@deprecated-claude/shared';
 
-// Maximum number of automatically detected participants to limit false positives
-const MAX_AUTO_DETECTED_PARTICIPANTS = 15;
+// Maximum number of automatically detected participants. Originally 15 to
+// guard against false positives in noisy text formats (cursor markdown,
+// colon-delimited dumps). Raised to 100 for chapterx_prompt and other
+// structured-marker formats where detection is reliable and large Discord
+// rooms routinely exceed 15 distinct speakers. The cap still exists as a
+// safety net against pathological inputs. Antra follow-up: confirm 100 is
+// the right ceiling, or whether the cap should be per-format.
+const MAX_AUTO_DETECTED_PARTICIPANTS = 100;
 
 export interface ParseOptions {
   // If provided, only these names will be treated as message headers
@@ -47,6 +53,9 @@ export class ImportParser {
         break;
       case 'colon_double':
         ({ messages, title, metadata } = await this.parseColonFormat(content, '\n\n', options?.allowedParticipants));
+        break;
+      case 'chapterx_prompt':
+        ({ messages, title, metadata } = await this.parseChapterXPrompt(content));
         break;
       default:
         throw new Error(`Unsupported format: ${format}`);
@@ -1040,5 +1049,232 @@ export class ImportParser {
     
     // Return messages in sorted order
     return sortedIndices.map(i => messages[i]);
+  }
+
+  /**
+   * Parse a ChapterX prompt-dump TXT export.
+   *
+   * Format spec (observed from chapterx's user-accessible Discord prompt-dump
+   * command, rendered via @animalabs/membrane):
+   *
+   *   # Prompt — <modelId>
+   *   # temperature: <n>
+   *   # max_tokens: <n>
+   *   <blank line>
+   *   === SYSTEM ===
+   *   <multi-line system prompt>
+   *   <blank line>
+   *   === CONVERSATION ===
+   *   <blank line>
+   *   [user]                      <- block-start marker, role=user
+   *   SkyeShark (Utah Teapot): <message content possibly spanning multiple lines>
+   *   <blank line>
+   *   --- user ---                <- continuation marker, role=user
+   *   Opus 4.7: <message content>
+   *   <blank line>
+   *   [assistant]                 <- block-start marker, role=assistant
+   *   <message content, no speaker prefix>
+   *
+   * Both `[role]` and `--- role ---` denote a new message of `role`. Membrane
+   * uses the bracket form for first-in-block and the dash form for subsequent
+   * same-role messages from different speakers; for Arc, both yield a fresh
+   * ParsedMessage with that role.
+   *
+   * Speaker name policy: verbatim. We do not split "SkyeShark (Utah Teapot)"
+   * into username/displayName because chapterx's <@mention> syntax uses the
+   * full display string; preserving it as-is keeps mention cross-references
+   * intact in message content.
+   *
+   * Role policy: trust the marker. Models that appear as user-role (e.g.
+   * `[user] Opus 4.7: ...`) are imported as user-role participants, because
+   * that is how the source-of-truth assistant saw them at generation time.
+   *
+   * Decisions documented in PR description.
+   */
+  private async parseChapterXPrompt(content: string): Promise<{ messages: ParsedMessage[], title?: string, metadata?: any }> {
+    // 1. Extract header lines (model / temperature / max_tokens)
+    const headerModelMatch = content.match(/^#\s*Prompt\s*[—-]\s*(.+?)\s*$/m);
+    const headerTempMatch = content.match(/^#\s*temperature:\s*([\d.]+)\s*$/m);
+    const headerMaxTokensMatch = content.match(/^#\s*max_tokens:\s*(\d+)\s*$/m);
+
+    const modelRaw = headerModelMatch ? headerModelMatch[1].trim() : undefined;
+    const temperature = headerTempMatch ? parseFloat(headerTempMatch[1]) : undefined;
+    const maxTokensHeader = headerMaxTokensMatch ? parseInt(headerMaxTokensMatch[1], 10) : undefined;
+
+    // 2. Extract system prompt and conversation body
+    let systemPrompt = '';
+    let conversation = content;
+    const systemRegex = /===\s*SYSTEM\s*===\s*\n([\s\S]*?)\n\s*===\s*CONVERSATION\s*===/i;
+    const systemMatch = content.match(systemRegex);
+    if (systemMatch) {
+      systemPrompt = systemMatch[1].trim();
+      conversation = content.slice(systemMatch.index! + systemMatch[0].length).trim();
+    } else {
+      const convoOnly = content.match(/===\s*CONVERSATION\s*===/i);
+      if (convoOnly) {
+        conversation = content.slice(convoOnly.index! + convoOnly[0].length).trim();
+      } else {
+        throw new Error('ChapterX prompt: missing === CONVERSATION === marker');
+      }
+    }
+
+    // 3. Walk the conversation, splitting on role markers.
+    //
+    // A "marker line" is one of:
+    //   [user]       [assistant]
+    //   --- user --- --- assistant ---
+    // Each marker starts a new ParsedMessage of that role. Content lines that
+    // follow accumulate into the current message until the next marker or EOF.
+    const MARKER_RE = /^\s*(?:\[(user|assistant)\]|---\s*(user|assistant)\s*---)\s*$/i;
+
+    type Block = { role: 'user' | 'assistant'; lines: string[] };
+    const blocks: Block[] = [];
+    let current: Block | null = null;
+
+    for (const line of conversation.split('\n')) {
+      const m = line.match(MARKER_RE);
+      if (m) {
+        if (current) blocks.push(current);
+        const role = (m[1] || m[2]).toLowerCase() as 'user' | 'assistant';
+        current = { role, lines: [] };
+      } else if (current) {
+        current.lines.push(line);
+      }
+      // Lines before the first marker (shouldn't happen after our slicing,
+      // but be defensive) are dropped.
+    }
+    if (current) blocks.push(current);
+
+    // 4. Convert blocks into ParsedMessages.
+    //
+    // For user blocks: the first non-empty line is `SpeakerName: content`.
+    // For assistant blocks: no speaker prefix; the whole block is content,
+    // and we infer the assistant participant name from the model header (or
+    // fall back to "Assistant").
+    const assistantName = this.inferChapterXAssistantName(modelRaw);
+    const messages: ParsedMessage[] = [];
+
+    for (const block of blocks) {
+      const text = block.lines.join('\n').trim();
+      if (!text) continue;
+
+      if (block.role === 'assistant') {
+        messages.push({
+          role: 'assistant',
+          content: text,
+          participantName: assistantName,
+        });
+      } else {
+        const { name, body } = this.parseChapterXUserBlock(text);
+        if (!body) continue;
+        messages.push({
+          role: 'user',
+          content: body,
+          participantName: name,
+        });
+      }
+    }
+
+    // 5. Estimate rolling-context defaults from total content size.
+    //
+    // Arc's existing token-estimation heuristic is `chars / 4`. We round
+    // maxTokens down to the nearest 10k (floor at 20k) so future turns are
+    // poised to roll at roughly the conversation's current size, mirroring
+    // chapterx's rolling-context behavior. Grace is a flat 10k.
+    const totalChars = messages.reduce((sum, m) => sum + m.content.length, 0)
+      + systemPrompt.length;
+    const estimatedTokens = Math.ceil(totalChars / 4);
+    const rollingMaxTokens = Math.max(20_000, Math.floor(estimatedTokens / 10_000) * 10_000);
+    const rollingGraceTokens = 10_000;
+
+    const warnings: string[] = [];
+    // The TXT format references attachments by URL only; base64 image data is
+    // stripped by the chapterx render path. Flag this so users know the import
+    // is lossy for media. (Detection is heuristic: if message bodies reference
+    // URLs that look like attachment CDNs, mention them.)
+    const cdnHits = messages.filter(m => /https?:\/\/[^\s]+(cdn\.discordapp|attachments|media\.discordapp)/i.test(m.content)).length;
+    if (cdnHits > 0) {
+      warnings.push(`${cdnHits} message(s) reference Discord attachments by URL; base64 image data is not preserved in this format.`);
+    }
+
+    return {
+      messages,
+      title: modelRaw ? `Discord Transcript — ${modelRaw}` : 'Discord Transcript',
+      metadata: {
+        source: 'chapterx_prompt',
+        systemPrompt,
+        // The cosmetic name used for the assistant participant. Persisted in
+        // metadata so the import route can target the source-side assistant
+        // specifically (system prompt + sampling params should apply only to
+        // it, not to other assistant participants the user may have created
+        // via remapping or that exist as Arc defaults).
+        assistantName,
+        model: { raw: modelRaw },
+        params: {
+          temperature,
+          maxTokens: maxTokensHeader,
+        },
+        rollingDefaults: {
+          maxTokens: rollingMaxTokens,
+          maxGraceTokens: rollingGraceTokens,
+          estimatedConversationTokens: estimatedTokens,
+        },
+        warnings,
+      }
+    };
+  }
+
+  /**
+   * Parse a single user-block body of the form `Speaker Name: message text`.
+   * Multi-line messages: only the first non-empty line carries the prefix; the
+   * remainder is preserved verbatim. If no `Name:` prefix is found (unusual
+   * but possible), we attribute to a generic "User" participant and keep the
+   * full body as content.
+   */
+  private parseChapterXUserBlock(text: string): { name: string; body: string } {
+    const lines = text.split('\n');
+    const firstNonEmptyIdx = lines.findIndex(l => l.trim().length > 0);
+    if (firstNonEmptyIdx === -1) return { name: 'User', body: '' };
+
+    const firstLine = lines[firstNonEmptyIdx];
+    // Speaker prefix: up to ~80 chars, no newlines, followed by ": ".
+    // We accept paren-wrapped display names (e.g. "SkyeShark (Utah Teapot):").
+    const prefixMatch = firstLine.match(/^([^:\n]{1,80}):\s*(.*)$/);
+    if (!prefixMatch) {
+      return { name: 'User', body: text };
+    }
+
+    const name = prefixMatch[1].trim();
+    const firstLineRest = prefixMatch[2];
+    const rest = lines.slice(firstNonEmptyIdx + 1);
+    const bodyLines = firstLineRest ? [firstLineRest, ...rest] : rest;
+    return { name, body: bodyLines.join('\n').trim() };
+  }
+
+  /**
+   * Infer a human-readable assistant participant name from the model header.
+   * This is purely cosmetic (used as participantName); the actual Arc model
+   * binding is resolved separately at import time against Arc's model registry.
+   * Examples:
+   *   "claude-opus-4-8" -> "Opus 4.8"
+   *   "claude-sonnet-4-5" -> "Sonnet 4.5"
+   *   "gpt-5" -> "GPT 5"
+   *   unknown -> "Assistant"
+   */
+  private inferChapterXAssistantName(modelRaw: string | undefined): string {
+    if (!modelRaw) return 'Assistant';
+    const opus = modelRaw.match(/claude[-_ ]?opus[-_ ]?(\d+)[-_ ]?(\d+)/i);
+    if (opus) return `Opus ${opus[1]}.${opus[2]}`;
+    const sonnet = modelRaw.match(/claude[-_ ]?sonnet[-_ ]?(\d+)[-_ ]?(\d+)/i);
+    if (sonnet) return `Sonnet ${sonnet[1]}.${sonnet[2]}`;
+    const haiku = modelRaw.match(/claude[-_ ]?haiku[-_ ]?(\d+)[-_ ]?(\d+)/i);
+    if (haiku) return `Haiku ${haiku[1]}.${haiku[2]}`;
+    const gpt = modelRaw.match(/^gpt[-_ ]?(\d+(?:[.-]\d+)?)/i);
+    if (gpt) return `GPT ${gpt[1].replace('-', '.')}`;
+    // Fallback: humanize the raw identifier
+    return modelRaw
+      .replace(/[-_]/g, ' ')
+      .replace(/\b\w/g, c => c.toUpperCase())
+      .trim() || 'Assistant';
   }
 }

--- a/deprecated-claude-app/frontend/src/components/ImportDialogV2.vue
+++ b/deprecated-claude-app/frontend/src/components/ImportDialogV2.vue
@@ -444,7 +444,7 @@
               <!-- Only show model selector for standard (1-on-1) format -->
               <!-- Group chats get models from participant mappings -->
               <v-select
-                v-if="conversationFormat === 'standard'"
+                v-if="conversationFormat === 'standard' || selectedFormat === 'chapterx_prompt'"
                 v-model="selectedModel"
                 :items="activeModels"
                 item-title="displayName"
@@ -456,13 +456,78 @@
               />
 
               <v-alert
-                v-if="conversationFormat === 'prefill' && hasMultipleParticipants"
+                v-if="conversationFormat === 'prefill' && hasMultipleParticipants && selectedFormat !== 'chapterx_prompt'"
                 type="info"
                 density="compact"
                 class="mt-4"
               >
                 Group chat detected. Participant models will be preserved from the import.
               </v-alert>
+
+              <!-- ChapterX-specific: model resolution + system prompt toggle + rolling context info -->
+              <template v-if="selectedFormat === 'chapterx_prompt' && preview?.metadata">
+                <v-alert
+                  :type="preview.metadata.model?.resolved?.matched ? 'success' : 'warning'"
+                  density="compact"
+                  class="mt-4"
+                  variant="tonal"
+                >
+                  <div v-if="preview.metadata.model?.resolved?.matched">
+                    Model resolved: <strong>{{ preview.metadata.model.resolved.displayName }}</strong>
+                    <span class="text-caption d-block mt-1">
+                      Source identifier: <code>{{ preview.metadata.model.raw }}</code>
+                    </span>
+                  </div>
+                  <div v-else>
+                    Model <code>{{ preview.metadata.model?.raw || 'unknown' }}</code> not in registry.
+                    <span class="text-caption d-block mt-1">
+                      Pick a substitute from the dropdown above. You can change it later on the assistant participant.
+                    </span>
+                  </div>
+                </v-alert>
+
+                <v-alert
+                  type="info"
+                  density="compact"
+                  class="mt-4"
+                  variant="tonal"
+                >
+                  Rolling context will be set to
+                  <strong>{{ formatTokenCount(preview.metadata.rollingDefaults?.maxTokens) }}</strong>
+                  + <strong>{{ formatTokenCount(preview.metadata.rollingDefaults?.maxGraceTokens) }}</strong> grace
+                  <span class="text-caption d-block mt-1">
+                    Estimated conversation size: {{ formatTokenCount(preview.metadata.rollingDefaults?.estimatedConversationTokens) }}.
+                    Editable in conversation settings post-import.
+                  </span>
+                </v-alert>
+
+                <v-checkbox
+                  v-model="importSystemPrompt"
+                  :disabled="!preview.metadata.systemPrompt"
+                  label="Import system prompt onto assistant participant"
+                  density="compact"
+                  hide-details
+                  class="mt-2"
+                />
+                <div v-if="preview.metadata.systemPrompt" class="text-caption text-medium-emphasis ml-10">
+                  {{ preview.metadata.systemPrompt.length }} chars. Includes chapterx framing
+                  (Discord connection, rolling context). Untoggle to start fresh.
+                </div>
+                <div v-else class="text-caption text-medium-emphasis ml-10">
+                  No system prompt found in source.
+                </div>
+
+                <v-alert
+                  v-for="(warning, idx) in preview.metadata.warnings || []"
+                  :key="idx"
+                  type="warning"
+                  density="compact"
+                  variant="tonal"
+                  class="mt-3"
+                >
+                  {{ warning }}
+                </v-alert>
+              </template>
             </v-card-text>
 
             <v-card-actions>
@@ -481,7 +546,7 @@
               </v-btn>
               <v-btn
                 :loading="loading"
-                :disabled="conversationFormat === 'standard' && !selectedModel"
+                :disabled="(conversationFormat === 'standard' || selectedFormat === 'chapterx_prompt') && !selectedModel"
                 color="primary"
                 variant="elevated"
                 @click="executeImport"
@@ -581,6 +646,19 @@ const archiveUploadPct = ref(0);
 // Step 3: Configuration
 const conversationTitle = ref('');
 const conversationFormat = ref<'standard' | 'prefill'>('standard');
+// ChapterX-specific: whether to import the source system prompt onto the
+// assistant participant. Toggleable in step 2. Default true — most users want
+// the imported conversation ready to continue with the same identity framing.
+const importSystemPrompt = ref(true);
+
+// Small helper for token counts in the chapterx info alerts.
+// Renders e.g. 70000 as "70k", 1500 as "1.5k", undefined as "—".
+function formatTokenCount(n: number | undefined | null): string {
+  if (n == null || isNaN(n)) return '—';
+  if (n < 1000) return String(n);
+  const k = n / 1000;
+  return (k >= 10 ? Math.round(k) : k.toFixed(1).replace(/\.0$/, '')) + 'k';
+}
 const selectedModel = ref('');
 const archiveModel = ref('');
 const archiveContentMode = ref<ClaudeArchiveContentMode>('rendered');
@@ -641,6 +719,11 @@ const formatOptions = [
     value: 'colon_double',
     label: 'Colon Format (Double Line)',
     description: 'Name: message\\n\\nName: message'
+  },
+  {
+    value: 'chapterx_prompt',
+    label: 'ChapterX Prompt',
+    description: 'Text dump from chapterx\'s Discord prompt command (.txt). Preserves system prompt, model identity, and rolling-context settings.'
   }
 ];
 
@@ -654,7 +737,8 @@ const formatLabels: Record<string, string> = {
   cursor_json: 'Cursor (JSON)',
   openai: 'OpenAI',
   colon_single: 'text',
-  colon_double: 'text'
+  colon_double: 'text',
+  chapterx_prompt: 'ChapterX prompt'
 };
 
 const conversationFormatOptions = [
@@ -816,6 +900,18 @@ async function previewImport() {
           selectedModel.value = matchingModel.id;
         }
       }
+    } else if (selectedFormat.value === 'chapterx_prompt') {
+      // ChapterX metadata.model is structured: { raw, resolved? }
+      // resolved.matched signals whether the backend found a registry hit.
+      // On match: pre-select it. On miss: leave selectedModel empty so the
+      // user has to pick consciously (Import button is disabled until then).
+      // Defensive: backend also returns 400 if no model is sent on a miss.
+      const cxModel = preview.value.metadata?.model;
+      if (cxModel?.resolved?.matched && cxModel.resolved.id) {
+        selectedModel.value = cxModel.resolved.id;
+      } else {
+        selectedModel.value = '';
+      }
     } else {
       // Try to match the model from the import metadata for other formats
       const importedModel = preview.value.metadata?.model;
@@ -912,8 +1008,13 @@ async function executeImport() {
       allowedParticipants, // Pass to server for re-parsing
       conversationFormat: conversationFormat.value,
       title: conversationTitle.value,
-      // Only include model for standard format - group chats derive from participants
-      ...(conversationFormat.value === 'standard' && selectedModel.value && { model: selectedModel.value })
+      // Include model for standard format (group chats normally derive from
+      // participants). chapterx_prompt is an exception: it has a single
+      // canonical assistant model that the dropdown lets the user override.
+      ...((conversationFormat.value === 'standard' || selectedFormat.value === 'chapterx_prompt')
+        && selectedModel.value && { model: selectedModel.value }),
+      // ChapterX-specific: respect the system-prompt-import toggle.
+      ...(selectedFormat.value === 'chapterx_prompt' && { importSystemPrompt: importSystemPrompt.value })
     });
     
     // Reload conversations to include the new one
@@ -1057,6 +1158,7 @@ function resetState() {
   conversationTitle.value = '';
   conversationFormat.value = 'standard';
   selectedModel.value = '';
+  importSystemPrompt.value = true;
   archiveModel.value = '';
   archiveContentMode.value = 'rendered';
   archiveIncludeEmpty.value = false;

--- a/deprecated-claude-app/shared/src/import-types.ts
+++ b/deprecated-claude-app/shared/src/import-types.ts
@@ -54,7 +54,20 @@ export const ImportFormatSchema = z.enum([
   'cursor',
   'cursor_json',
   'colon_single',
-  'colon_double'
+  'colon_double',
+  // ChapterX prompt export — text format produced by chapterx's user-accessible
+  // prompt-dump Discord command (rendered via @animalabs/membrane). Format:
+  //   # Prompt — <modelId>
+  //   # temperature: <n>
+  //   # max_tokens: <n>
+  //   === SYSTEM ===
+  //   <system prompt text>
+  //   === CONVERSATION ===
+  //   [user] | [assistant] | --- user --- | --- assistant ---
+  //   <SpeakerName: content> (user blocks) or <content> (assistant blocks)
+  // Speaker names are preserved verbatim (e.g. "SkyeShark (Utah Teapot)").
+  // Mentions like <@Opus 4.7> are name-based and preserved as raw text.
+  'chapterx_prompt'
 ]);
 
 export type ImportFormat = z.infer<typeof ImportFormatSchema>;
@@ -91,7 +104,11 @@ export const ImportRequestSchema = z.object({
   participantMappings: z.array(ParticipantMappingSchema).optional(),
   conversationFormat: z.enum(['standard', 'prefill']),
   title: z.string().optional(),
-  model: z.string().optional() // Optional for group chats - derived from first assistant participant
+  model: z.string().optional(), // Optional for group chats - derived from first assistant participant
+  // ChapterX-specific: import the source system prompt onto the assistant
+  // participant. Defaults to true server-side. UI toggle exposes this so users
+  // can opt out and start with Arc defaults.
+  importSystemPrompt: z.boolean().optional()
 });
 
 export type ImportRequest = z.infer<typeof ImportRequestSchema>;


### PR DESCRIPTION
## Summary

First-party import for chapterx's user-accessible Discord prompt-dump format (rendered by `@animalabs/membrane`). Lands the conversation ready to continue: model resolved against Arc's registry, rolling-context configured at conversation size, system prompt + sampling params applied to the source-side assistant participant.

## Locked decisions

| Topic | Decision |
|---|---|
| Speaker name | Verbatim chapterx string (e.g. `SkyeShark (Utah Teapot)`, `Opus 4.7`) — preserves cross-referent with `<@…>` mentions |
| Mentions | Left as raw text — no ID resolution (chapterx uses name-based `<@DisplayName>`, no IDs to chase) |
| `[role]` vs `--- role ---` markers | Both = new message of that role. Parser treats identically. |
| Role policy | Trust the marker — models tagged as `user` import as user-role participants, matching how the source-side assistant saw them at generation time |
| System prompt destination | Assistant participant's `systemPrompt` field. UI toggle (default ON) lets the user opt out to start fresh. Source-side identity (chapterx's framing) is preserved verbatim when on; users can edit post-import. |
| Model identity | Strict lookup against `backend/config/models.json` (matches `providerModelId`, `id`, or `canonicalId`). UI prompts user to pick from dropdown on miss; backend returns 400 as defensive backstop if no resolved-or-explicit model. |
| Participant cap | Raised 15→100 globally with code comment noting Antra follow-up |
| Title | `Discord Transcript — {modelRaw}` (editable post-import) |
| Rolling context defaults | `maxTokens = max(20k, floor(estimatedTokens / 10k) * 10k)`, `maxGraceTokens = 10000`. Tokens estimated via Arc's `chars/4` heuristic, mirroring chapterx's rolling-context behavior. |
| Assistant participant targeting | Parser surfaces `metadata.assistantName`; route applies system prompt + sampling params only to that participant (via `participantMap`), not all assistants. |

## What's lossy

- Attachment base64 (chapterx renders URLs only); parser surfaces a warning when CDN-style links are detected
- Discord mention IDs (chapterx renders display-name mentions, not numeric IDs)
- The system prompt carries chapterx's Discord-specific framing ("connected to Discord", "rolling context"); users can opt out via the toggle to start fresh

## Open questions for @antra-tess

- Is `100` the right ceiling for the auto-detected-participants cap, or should it be per-format? Code-comment marks the change as a follow-up.
- The format spec was reverse-engineered from a real sample — confirmed the markers don't appear literally in chapterx or `@animalabs/membrane` local source (likely template-string assembly we couldn't grep). If Membrane changes the format upstream, the parser will need corresponding updates.

## Test plan

- [ ] Import the canonical sample via the UI (`prompt-opus48-…txt`); verify 470 messages, 34 participants visible, Opus 4.8 is the only assistant
- [ ] After import, verify in conversation settings: rolling strategy with 70k + 10k grace
- [ ] After import, verify assistant participant has chapterx system prompt + `temperature=1` + `maxTokens=4096`
- [ ] Test the system-prompt-import toggle off: assistant participant should have empty system prompt
- [ ] Test model-registry miss: try a chapterx file whose model header doesn't match registry — UI should disable Import until a substitute is picked; submitting via API without a model should return 400
- [ ] Send a message in the imported conversation; verify Opus 4.8 responds with personality consistent with chapterx framing

🤖 Generated with [Claude Code](https://claude.com/claude-code)