### PR TITLE
fix: support ai chat exporter json imports

### DIFF
--- a/deprecated-claude-app/backend/src/services/importParser.ts
+++ b/deprecated-claude-app/backend/src/services/importParser.ts
@@ -220,6 +220,43 @@ export class ImportParser {
 
   private async parseChromeExtension(content: string): Promise<{ messages: ParsedMessage[], title?: string, metadata?: any }> {
     const data = JSON.parse(content);
+
+    // ai-chat-exporter.net / "Claude Exporter" JSON shape:
+    // {
+    //   metadata: { title, dates, link, powered_by },
+    //   messages: [{ role: "human" | "assistant", time, say }]
+    // }
+    // This is distinct from the Claude Conversation Exporter extension's
+    // `chat_messages` shape below, but it is exposed to users under the same
+    // "Claude Exporter" naming, so support it in this importer.
+    if (data.metadata && Array.isArray(data.messages) && data.messages.some((msg: any) => typeof msg.say === 'string')) {
+      const messages: ParsedMessage[] = data.messages
+        .map((msg: any) => {
+          const textContent = typeof msg.say === 'string' ? msg.say : '';
+          if (!textContent.trim()) return null;
+
+          return {
+            role: msg.role === 'assistant' ? 'assistant' : 'user',
+            content: textContent,
+            timestamp: msg.time ? new Date(msg.time) : undefined,
+            model: msg.model || data.metadata?.model
+          } satisfies ParsedMessage;
+        })
+        .filter((msg: ParsedMessage | null): msg is ParsedMessage => msg !== null);
+
+      return {
+        messages,
+        title: data.metadata.title || 'Imported Conversation',
+        metadata: {
+          source: 'ai-chat-exporter',
+          link: data.metadata.link,
+          powered_by: data.metadata.powered_by,
+          created_at: data.metadata.dates?.created,
+          updated_at: data.metadata.dates?.updated,
+          exported_at: data.metadata.dates?.exported
+        }
+      };
+    }
     
     // Extract basic conversation metadata
     const title = data.name || data.summary || 'Imported Conversation';


### PR DESCRIPTION
## Summary

Adds compatibility for ai-chat-exporter.net / "Claude Exporter" JSON files under the existing Claude Conversation Exporter import option.

## Root Cause

Arc's `chrome_extension` importer only read the older `chat_messages[]` shape. The exported file Jake tested uses:

```json
{
  "metadata": { "title": "...", "powered_by": "Claude Exporter (...)" },
  "messages": [{ "role": "human", "time": "...", "say": "..." }]
}
```

Because `chat_messages` was absent, preview returned zero messages.

## Changes

- Detect `metadata + messages[].say` exporter shape in `parseChromeExtension`
- Map `human` to `user`, `assistant` to `assistant`
- Use `say` as message content and `time` as timestamp
- Preserve title/link/export metadata where present

## Test Plan

- Parsed `/home/jake/Downloads/Claude-Glosso app and the risks of anonymous peer ratings.json`
  - 26 messages
  - 13 user / 13 assistant
  - title preserved
- `npm run build -w shared`
- `npm run build -w backend`
