### PR TITLE
Fix OpenRouter responder prefixes in messages mode

### DIFF
--- a/deprecated-claude-app/backend/src/services/inference.ts
+++ b/deprecated-claude-app/backend/src/services/inference.ts
@@ -1480,7 +1480,7 @@ export class InferenceService {
         if (participantName === '') {
           // Raw continuation - no prefix
           formattedContent = activeBranch.content;
-        } else if (role === 'assistant' && (provider === 'openai-compatible' || provider === 'anthropic' || provider === 'bedrock')) {
+        } else if (role === 'assistant' && (provider === 'openai-compatible' || provider === 'openrouter' || provider === 'anthropic' || provider === 'bedrock')) {
           // Assistant's own messages - no prefix (prevents the model from echoing its name,
           // which triggers stop sequences in messages mode)
           formattedContent = activeBranch.content;

--- a/deprecated-claude-app/backend/src/services/inference.ts
+++ b/deprecated-claude-app/backend/src/services/inference.ts
@@ -266,9 +266,13 @@ export class InferenceService {
     // outputs the full file content (which starts with participant names that would
     // trigger stop sequences prematurely). Post-facto stop sequences handle turn-taking.
     let stopSequences: string[] | undefined;
+    const responderForStopSequences = responderId
+      ? participants.find(p => p.id === responderId && p.name !== '')
+      : undefined;
+    const responderStopSequence = responderForStopSequences ? `${responderForStopSequences.name}:` : undefined;
     if (actualFormat === 'prefill' || actualFormat === 'messages') {
       // Always include these common stop sequences
-      const baseStopSequences = ['User:', 'A:', "Claude:"];
+      const baseStopSequences = ['User:', 'A:', "Claude:"].filter(s => s !== responderStopSequence);
       // Add participant names as stop sequences (excluding empty names and the current responder)
       // The responder must be excluded because the model will prefix its response with its own name
       const participantStopSequences = participants
@@ -299,7 +303,7 @@ export class InferenceService {
     // Since this is applied in our code, not the API, we can check for ALL participants
     const needsPostFactoStopSequences = (actualFormat === 'prefill' || actualFormat === 'messages') && participants.length > 0;
     const postFactoStopSequences = needsPostFactoStopSequences ? (() => {
-      const baseStopSequences = ['User:', 'A:', "Claude:"];
+      const baseStopSequences = ['User:', 'A:', "Claude:"].filter(s => s !== responderStopSequence);
       const participantStopSequences = participants
         .filter(p => p.name !== '' && p.id !== responderId)
         .map(p => `${p.name}:`);


### PR DESCRIPTION
## Summary

Fix messages-mode formatting for OpenRouter-backed multi-participant chats so the active responder is not cued into immediately hitting its own stop sequence.

## Root Cause

In messages mode, Arc already avoids prefixing the active responder's own assistant-history messages for Anthropic, Bedrock, and OpenAI-compatible providers. OpenRouter was missing from that condition, so Claude's own prior turns could be sent as assistant messages whose content began with `Claude:`.

At the same time, fallback stop sequences always included hard-coded `Claude:` and `A:` even when one of those names was the active responder. For OpenRouter + Claude, this could make the model begin with `Claude:` and then immediately stop, returning an empty response with `finish_reason: "stop"`.

## Changes

- Treat OpenRouter like the other provider paths when formatting the responder's own assistant history: no name prefix.
- Remove the active responder's own name from fallback API and post-facto stop sequences, including hard-coded base stops.

## Validation

- `npm run build -w shared`
- `npm run build -w backend`
- Deployed equivalent patch to `snav.chat`; confirmed the affected conversation no longer returns empty Claude responses.
