### PR TITLE
Skip credit check for self-hosted custom-endpoint models

### DIFF
--- a/deprecated-claude-app/backend/src/websocket/handler.ts
+++ b/deprecated-claude-app/backend/src/websocket/handler.ts
@@ -282,6 +282,18 @@ async function userHasSufficientCredits(db: Database, userId: string, modelId?: 
     const modelLoader = ModelLoader.getInstance();
     const model = await modelLoader.getModelById(modelId, userId);
     if (model) {
+      // Self-hosted custom endpoints (openai-compatible models with an embedded
+      // baseUrl) have no platform cost basis — pricing resolves to $0 and the
+      // inference path already bypasses the API-key manager for them
+      // (see InferenceService: `isCustomModelWithEndpoint`). Charging credits
+      // here would lock the user out of a model that costs the platform nothing,
+      // so skip the credit check entirely, mirroring the "user brought their own
+      // API key" exemption below.
+      if (model.customEndpoint) {
+        console.log(`[Credits] User ${userId} using custom-endpoint model ${model.id}, skipping credit check`);
+        return true;
+      }
+
       // Check if user has their own API key for this provider
       const userApiKeys = await db.getUserApiKeys(userId);
       const hasProviderKey = userApiKeys.some(key => key.provider === model.provider);

--- a/deprecated-claude-app/shared/src/types.ts
+++ b/deprecated-claude-app/shared/src/types.ts
@@ -177,7 +177,16 @@ export const ModelSchema = z.object({
   supportsPrefill: z.boolean().optional(), // Whether model supports prefill/completion mode (defaults based on provider)
   capabilities: ModelCapabilitiesSchema.optional(), // Multimodal capabilities
   currencies: z.record(z.boolean()).optional(),
-  
+
+  // Custom endpoint settings, present when this Model was derived from a
+  // user-defined openai-compatible model with an embedded baseUrl. Spread on
+  // in ModelLoader.getAllModels; declared here so consumers (credit gating,
+  // inference routing) can read it type-safely.
+  customEndpoint: z.object({
+    baseUrl: z.string().url(),
+    apiKey: z.string().optional()
+  }).optional(),
+
   // Model-specific configurable settings (rendered as dynamic UI)
   configurableSettings: z.array(ConfigurableSettingSchema).optional(),
   


### PR DESCRIPTION
Models configured with their own OpenAI-compatible endpoint (`customEndpoint.baseUrl`) have no platform cost basis: pricing resolves to \$0 and the inference path already bypasses the API-key manager for them (`InferenceService.isCustomModelWithEndpoint`). But the credit gate in `userHasSufficientCredits` did not account for this, so a user with no grant balance is blocked with "Insufficient credits" from a model that costs the platform nothing to serve.

## Fix

Skip the credit check when the model carries a `customEndpoint`, mirroring the existing "user brought their own API key" exemption directly below it in the same function.

## Type correctness

`ModelLoader.getAllModels` already spreads `customEndpoint` onto the `Model` objects it derives from user-defined models, but `ModelSchema` did not declare the field — so the type was omitting something present at runtime, and consumers reading `model.customEndpoint` had to do so untyped. This PR adds `customEndpoint` to `ModelSchema` (same shape as `UserDefinedModelSchema`), making the access in the credit gate type-safe.

## Tradeoff worth flagging

This bakes in the assumption that a self-hosted custom endpoint is never credit-metered. That is correct when the platform has no cost relationship with the endpoint (the operator runs it themselves). A multi-tenant host that wanted to meter even BYO-endpoint usage would want this behind a config flag instead. Happy to gate it if that is a concern for the project's deployment model.

## Files

- `backend/src/websocket/handler.ts` — credit-gate skip
- `shared/src/types.ts` — `customEndpoint` on `ModelSchema`