### PR TITLE
fix(anthropic): support Claude Fable 5 (adaptive thinking + premium cache)

### DIFF
--- a/deprecated-claude-app/backend/src/services/anthropic.ts
+++ b/deprecated-claude-app/backend/src/services/anthropic.ts
@@ -111,7 +111,18 @@ export class AnthropicService {
       }
       
       // Determine if this model uses adaptive thinking (Opus 4.7+) vs legacy enabled thinking
-      const useAdaptiveThinking = modelId.includes('opus-4-7') || modelId.includes('opus-4-8') || modelId.includes('opus-4-9') || modelId.includes('opus-5');
+      // Models that require adaptive thinking (`type: 'adaptive'` + `output_config.effort`)
+      // rather than legacy `type: 'enabled' + budget_tokens`. Anthropic 400s with
+      // "thinking.type.enabled is not supported for this model" if this is wrong.
+      // FIXME: this is a brittle substring allowlist — long-term the model entry
+      // should declare its thinking-API shape (cf. issue #121's note on hardcoded
+      // model registries; same pattern as the pricing-table fix in #120).
+      const useAdaptiveThinking =
+        modelId.includes('opus-4-7') ||
+        modelId.includes('opus-4-8') ||
+        modelId.includes('opus-4-9') ||
+        modelId.includes('opus-5') ||
+        modelId.includes('fable-5');
 
       // Ensure max_tokens > budget_tokens when legacy thinking is enabled
       let effectiveMaxTokens = settings.maxTokens;

--- a/deprecated-claude-app/backend/src/services/cache-strategies.ts
+++ b/deprecated-claude-app/backend/src/services/cache-strategies.ts
@@ -5,6 +5,21 @@
 
 import { Message } from '@deprecated-claude/shared';
 
+/**
+ * Models that use Anthropic's premium cache tier (longer TTL, lower token
+ * threshold for caching to be worthwhile). Currently the Opus family and the
+ * Fable family — historically detected by an inline `modelId.includes('opus')`
+ * check at every call site; this helper centralises it so new families don't
+ * silently fall back to the generic short-TTL/high-threshold defaults.
+ *
+ * FIXME: long-term this should come off the model's own config entry
+ * (e.g. a `cacheProfile` field) rather than a hardcoded family allowlist.
+ */
+function isPremiumCacheModel(modelId: string): boolean {
+  const m = modelId.toLowerCase();
+  return m.includes('opus') || m.includes('fable');
+}
+
 export enum CacheEvent {
   MISS = 'miss',           // No cache available
   HIT = 'hit',             // Full cache hit
@@ -76,7 +91,7 @@ export interface CacheStrategy {
  */
 export class DefaultCacheStrategy implements CacheStrategy {
   onCacheExpired(messages: Message[], lastCacheTime: Date, modelId: string): CacheDecision {
-    const isOpus = modelId.toLowerCase().includes('opus');
+    const isOpus = isPremiumCacheModel(modelId);
     const minutesSinceLast = (Date.now() - lastCacheTime.getTime()) / 1000 / 60;
     
     // For Opus, consider refresh if just barely expired
@@ -120,7 +135,7 @@ export class DefaultCacheStrategy implements CacheStrategy {
       reason: 'Creating initial cache',
       metadata: {
         tokensToCache: totalTokens,
-        expectedTTL: modelId.toLowerCase().includes('opus') ? 60 : 5
+        expectedTTL: isPremiumCacheModel(modelId) ? 60 : 5
       }
     };
   }
@@ -130,7 +145,7 @@ export class DefaultCacheStrategy implements CacheStrategy {
       action: CacheAction.REBUILD,
       reason: `Context rotated, dropped ${droppedCount} messages`,
       metadata: {
-        expectedTTL: modelId.toLowerCase().includes('opus') ? 60 : 5
+        expectedTTL: isPremiumCacheModel(modelId) ? 60 : 5
       }
     };
   }
@@ -176,7 +191,7 @@ export class AggressiveCacheStrategy extends DefaultCacheStrategy {
       reason: 'Attempting cache refresh to maintain continuity',
       metadata: {
         refreshTokens: 50, // Minimal tokens to refresh
-        expectedTTL: modelId.toLowerCase().includes('opus') ? 60 : 5
+        expectedTTL: isPremiumCacheModel(modelId) ? 60 : 5
       }
     };
   }
@@ -193,7 +208,7 @@ export class CostOptimizedCacheStrategy extends DefaultCacheStrategy {
     }, 0);
     
     // Only cache larger conversations where savings are significant
-    const threshold = modelId.toLowerCase().includes('opus') ? 2000 : 5000;
+    const threshold = isPremiumCacheModel(modelId) ? 2000 : 5000;
     
     if (totalTokens < threshold) {
       return {


### PR DESCRIPTION
Adding `claude-fable-5` to staging surfaced two hardcoded model-id allowlists that don't cover the Fable family, so every request 400s with `invalid_request_error: "thinking.type.enabled" is not supported for this model. Use "thinking.type.adaptive" and "output_config.effort"`.

## Two changes

**`anthropic.ts:114` — adaptive thinking allowlist.** Substring check (`opus-4-7|opus-4-8|opus-4-9|opus-5`) decides whether to send `thinking: {type:'adaptive'}` + `output_config.effort` vs the legacy `thinking: {type:'enabled', budget_tokens:N}`. Fable 5 only accepts the adaptive shape → added `fable-5`.

**`cache-strategies.ts` — premium cache tier.** Five inline `modelId.toLowerCase().includes('opus')` calls govern cache TTL (60min vs 5min) and the caching threshold (2000 vs 5000 tokens). Extracted a single `isPremiumCacheModel()` helper covering opus + fable so the next new family doesn't hit the same papercut.

Both call sites are the same brittle pattern as the pricing-table issue from #120 — they need to be lifted off hardcoded substrings onto a field on the model's own config entry (e.g. `cacheProfile`, `thinkingShape`). Marked with FIXMEs; proper follow-up rather than yet another inline allowlist edit per new family.

## Verification

- Reproduced the original 400 on staging with `claude-fable-5`: `"thinking.type.enabled" is not supported for this model`.
- Hot-patched the deployed `anthropic.js` on staging (matching change), restart, retry — the adaptive path is taken and the rejection is gone. This PR makes the same change durable through the next deploy.
- Typecheck clean for both modified files. (Main has some pre-existing TS errors from the recent merge batch — `EnrichedBookmark`/`chapterx_prompt`/`attachments` — that are fixed by rebuilding `shared/`; none are from this PR.)

## Test plan
- [x] Reproduce + diagnose against staging
- [x] Hot-patch staging, confirm the 400 stops
- [ ] After deploy: staging serves Fable 5 without the hot-patch
- [ ] Generation completes end-to-end on Fable 5 (watch for any follow-on incompatibilities like the `temperature` deprecation that hit Opus 4.8)

## Related
- #120 (same brittle-allowlist pattern in the pricing path)
- #121 (general note that hardcoded model registries silently rot)

🤖 Generated with [Claude Code](https://claude.com/claude-code)