### PR TITLE
chore(deploy): sync tracked models.json with live config (add Opus 4.8 + Fable 5)

### DIFF
--- a/deprecated-claude-app/backend/config/models.json
+++ b/deprecated-claude-app/backend/config/models.json
@@ -70,6 +70,145 @@
       }
     },
     {
+      "id": "claude-opus-4.8",
+      "providerModelId": "claude-opus-4-8",
+      "canonicalId": "claude-opus-4.8",
+      "displayName": "Claude Opus 4.8",
+      "shortName": "Opus 4.8",
+      "provider": "anthropic",
+      "hidden": false,
+      "contextWindow": 1000000,
+      "outputTokenLimit": 128000,
+      "supportsThinking": true,
+      "thinkingDefaultEnabled": true,
+      "supportsPrefill": false,
+      "currencies": {
+        "models-2025": true,
+        "credit": true
+      },
+      "configurableSettings": [
+        {
+          "type": "select",
+          "key": "thinkingEffort",
+          "label": "Thinking Effort",
+          "description": "Controls how much internal reasoning Opus 4.8 performs when extended thinking is enabled.",
+          "options": [
+            {
+              "value": "low",
+              "label": "Low",
+              "description": "Light reasoning, faster responses"
+            },
+            {
+              "value": "medium",
+              "label": "Medium",
+              "description": "Balanced depth and speed"
+            },
+            {
+              "value": "high",
+              "label": "High",
+              "description": "Deep, thorough reasoning"
+            }
+          ],
+          "default": "medium"
+        }
+      ],
+      "settings": {
+        "temperature": {
+          "min": 0,
+          "max": 1,
+          "default": 1,
+          "step": 0.1
+        },
+        "maxTokens": {
+          "min": 1,
+          "max": 128000,
+          "default": 8096
+        },
+        "topP": {
+          "min": 0,
+          "max": 1,
+          "default": 0.9,
+          "step": 0.01
+        },
+        "topK": {
+          "min": 1,
+          "max": 500,
+          "default": 40,
+          "step": 1
+        }
+      }
+    },
+    {
+      "id": "claude-fable-5",
+      "providerModelId": "claude-fable-5",
+      "canonicalId": "claude-fable-5",
+      "displayName": "Claude Fable 5",
+      "shortName": "Fable 5",
+      "provider": "anthropic",
+      "hidden": false,
+      "contextWindow": 1000000,
+      "outputTokenLimit": 128000,
+      "supportsThinking": true,
+      "thinkingDefaultEnabled": true,
+      "supportsPrefill": false,
+      "currencies": {
+        "models-2025": true,
+        "credit": true
+      },
+      "configurableSettings": [
+        {
+          "type": "select",
+          "key": "thinkingEffort",
+          "label": "Thinking Effort",
+          "description": "Controls how much internal reasoning Fable 5 performs when extended thinking is enabled.",
+          "options": [
+            {
+              "value": "low",
+              "label": "Low",
+              "description": "Light reasoning, faster responses"
+            },
+            {
+              "value": "medium",
+              "label": "Medium",
+              "description": "Balanced depth and speed"
+            },
+            {
+              "value": "high",
+              "label": "High",
+              "description": "Deep, thorough reasoning"
+            }
+          ],
+          "default": "medium"
+        }
+      ],
+      "settings": {
+        "temperature": {
+          "min": 0,
+          "max": 1,
+          "default": 1,
+          "step": 0.1
+        },
+        "maxTokens": {
+          "min": 1,
+          "max": 128000,
+          "default": 8096
+        },
+        "topP": {
+          "min": 0,
+          "max": 1,
+          "default": 0.9,
+          "step": 0.01
+        },
+        "topK": {
+          "min": 1,
+          "max": 500,
+          "default": 40,
+          "step": 1
+        }
+      },
+      "reasoningDisplay": "summarized"
+    },
+    {
       "id": "claude-sonnet-4.6",
       "providerModelId": "claude-sonnet-4-6",
       "canonicalId": "claude-sonnet-4.6",


### PR DESCRIPTION
## What the deploy actually reads

The deploy workflow (`.github/workflows/deploy-site.yml`) copies the **tracked** file `deprecated-claude-app/backend/config/models.json` into `/etc/<env>/models.json` on every deploy:

```sh
sudo -n cp "$DEPLOY_PATH/backend/config/models.json" "$CONFIG_PATH/models.json"
```

That tracked file has been drifting from live for months. Two new models — **Opus 4.8** (May session, \$5/\$25, 1M ctx) and **Fable 5** (today, \$10/\$50, 1M ctx, always-on summarized reasoning) — were added manually to `/etc/<env>/models.json` via one-off scripts but never made it into the tracked source. Result: **every deploy stomps them**.

Last bit us on the v1.7.0 deploy a few hours ago — both models disappeared from prod's dropdown and had to be re-injected manually. Same pattern hit staging earlier the same day.

## This PR

Adds the two missing entries to `backend/config/models.json`, inserted right after `claude-opus-4.7` to keep the Opus family contiguous (matching the position they currently live in on `/etc/<env>/models.json`). Fable 5 carries **`reasoningDisplay: "summarized"`** — see #132 — so the next deploy activates the always-on summarized-reasoning path on prod (prod's live entry doesn't have it yet; that's only on staging, which is why recent Fable refusals on prod returned full-reasoning payloads).

After this lands and a deploy goes out, `/etc/<env>/models.json` is recoverable from the tracked source instead of from local stashed scripts.

## What's *not* in this PR

The `production-models.json` at the repo root is gitignored (`production-*.json` rule in `.gitignore`), has never been tracked, and is not referenced by the deploy workflow. Leaving it alone — it's a red herring.

The brittle pattern (hardcoded model-id substring allowlists across `anthropic.ts`, `cache-strategies.ts`, the pricing-table) should ultimately move to per-model config fields. FIXMEs are in #120/#131/#132. This is just the routine sync.

## Test plan
- [x] JSON valid, model count goes 33 → 35
- [x] Diff is purely additive (+139, -0)
- [ ] After merge + tag: confirm `/etc/<env>/models.json` post-deploy still contains both models (i.e. no manual re-injection needed)
- [ ] Confirm Fable 5 on prod uses `display: 'summarized'` after #132's hot-patch is durable-ified via the same deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)