### PR TITLE
feat(frontend): export conversation as Markdown

### DIFF
--- a/deprecated-claude-app/frontend/src/store/index.ts
+++ b/deprecated-claude-app/frontend/src/store/index.ts
@@ -218,6 +218,131 @@ function sortMessagesByTreeOrder(messages: Message[]): Message[] {
   return sorted;
 }
 
+/**
+ * Compute the visible message path (the active branch path) for a set of
+ * messages, following each message's activeBranchId from the canonical root.
+ *
+ * This is the pure, store-independent core of the store's getVisibleMessages()
+ * method. It is shared so that features which operate on a conversation that is
+ * not the currently-loaded one (e.g. exporting an arbitrary conversation to
+ * markdown) can reuse the exact same path-resolution logic instead of
+ * reimplementing it.
+ *
+ * Handles multi-root conversations (from looming/branching) by selecting the
+ * canonical root as the one whose subtree has the most recent activity.
+ */
+export function computeVisibleMessages(messages: Message[]): Message[] {
+  // Sort messages by tree order to ensure parents come before children
+  // This handles cases where order numbers don't reflect tree structure
+  const sortedMessages = sortMessagesByTreeOrder(messages);
+
+  // For multi-root conversations (from looming/branching), find the canonical root
+  // Canonical root is the one whose subtree has the most recent activity
+  const rootMessages = sortedMessages.filter(msg => {
+    const activeBranch = msg.branches.find(b => b.id === msg.activeBranchId);
+    return activeBranch && (!activeBranch.parentBranchId || activeBranch.parentBranchId === 'root');
+  });
+
+  let canonicalRootId: string | null = null;
+  if (rootMessages.length > 1) {
+    // Multiple roots - pick the one with most recent activity in its subtree
+    // Build parent->children map
+    const parentToChildren = new Map<string, Message[]>();
+    for (const msg of sortedMessages) {
+      for (const branch of msg.branches) {
+        const parentId = branch.parentBranchId || 'root';
+        if (!parentToChildren.has(parentId)) {
+          parentToChildren.set(parentId, []);
+        }
+        parentToChildren.get(parentId)!.push(msg);
+      }
+    }
+
+    // Find latest timestamp in each root's subtree
+    let latestTime = 0;
+    for (const root of rootMessages) {
+      const rootTime = findLatestInSubtree(root, parentToChildren);
+      if (rootTime > latestTime) {
+        latestTime = rootTime;
+        canonicalRootId = root.id;
+      }
+    }
+    console.log(`[computeVisibleMessages] Multiple roots (${rootMessages.length}), canonical root: ${canonicalRootId?.slice(0, 8)}`);
+  } else if (rootMessages.length === 1) {
+    canonicalRootId = rootMessages[0].id;
+  }
+
+  // Helper function to find latest timestamp in a subtree
+  function findLatestInSubtree(root: Message, parentToChildren: Map<string, Message[]>): number {
+    let latest = 0;
+    const visited = new Set<string>();
+
+    function visit(msg: Message) {
+      if (visited.has(msg.id)) return;
+      visited.add(msg.id);
+
+      for (const branch of msg.branches) {
+        if (branch.createdAt) {
+          const time = new Date(branch.createdAt).getTime();
+          if (time > latest) latest = time;
+        }
+        // Visit children of this branch
+        const children = parentToChildren.get(branch.id) || [];
+        for (const child of children) visit(child);
+      }
+    }
+
+    visit(root);
+    return latest;
+  }
+
+  const visibleMessages: Message[] = [];
+  const branchPath: string[] = []; // Track the current conversation path (branch IDs)
+
+  for (let i = 0; i < sortedMessages.length; i++) {
+    const message = sortedMessages[i];
+    const activeBranch = message.branches.find(b => b.id === message.activeBranchId);
+
+    // Case 1: Active branch exists and is a root message
+    // Only accept the canonical root - skip others (handles multi-root conversations from looming)
+    if (activeBranch && (!activeBranch.parentBranchId || activeBranch.parentBranchId === 'root')) {
+      // Only accept if this is the canonical root (or if no canonical was determined)
+      if (branchPath.length === 0 && (!canonicalRootId || message.id === canonicalRootId)) {
+        visibleMessages.push(message);
+        branchPath.push(activeBranch.id);
+      }
+      // Skip other roots - they're from different conversation branches
+      continue;
+    }
+
+    // Case 2: Active branch exists and continues from our current path
+    if (activeBranch && branchPath.includes(activeBranch.parentBranchId!)) {
+      // This message is a valid continuation
+      visibleMessages.push(message);
+
+      // Find where in the path this branches from
+      const parentIndex = branchPath.indexOf(activeBranch.parentBranchId!);
+
+      // Truncate the path after the parent and add this branch
+      branchPath.length = parentIndex + 1;
+      branchPath.push(activeBranch.id);
+
+      continue;
+    }
+
+    // Case 3: Active branch doesn't exist or doesn't connect to our path
+    // Be strict: skip this message. Don't try to recover via other branches,
+    // as that can accidentally include orphaned/deleted branches from other roots.
+    // (This mirrors the import preview logic which is strict about following activeBranchId only)
+    if (!activeBranch) {
+      console.log('Skipping message with deleted active branch:', message.id);
+    }
+    // Message is from a different conversation path - skip it
+  }
+
+  return visibleMessages;
+}
+
 export function createStore(): {
   install(app: App): void;
 } {
@@ -1013,120 +1138,11 @@ export function createStore(): {
         return visibleMessagesCache.result;
       }
       
-      // Sort messages by tree order to ensure parents come before children
-      // This handles cases where order numbers don't reflect tree structure
-      const sortedMessages = sortMessagesByTreeOrder(state.allMessages);
-      
-      // For multi-root conversations (from looming/branching), find the canonical root
-      // Canonical root is the one whose subtree has the most recent activity
-      const rootMessages = sortedMessages.filter(msg => {
-        const activeBranch = msg.branches.find(b => b.id === msg.activeBranchId);
-        return activeBranch && (!activeBranch.parentBranchId || activeBranch.parentBranchId === 'root');
-      });
-      
-      let canonicalRootId: string | null = null;
-      if (rootMessages.length > 1) {
-        // Multiple roots - pick the one with most recent activity in its subtree
-        // Build parent->children map
-        const parentToChildren = new Map<string, Message[]>();
-        for (const msg of sortedMessages) {
-          for (const branch of msg.branches) {
-            const parentId = branch.parentBranchId || 'root';
-            if (!parentToChildren.has(parentId)) {
-              parentToChildren.set(parentId, []);
-            }
-            parentToChildren.get(parentId)!.push(msg);
-          }
-        }
-        
-        // Find latest timestamp in each root's subtree
-        let latestTime = 0;
-        for (const root of rootMessages) {
-          const rootTime = findLatestInSubtree(root, parentToChildren);
-          if (rootTime > latestTime) {
-            latestTime = rootTime;
-            canonicalRootId = root.id;
-          }
-        }
-        console.log(`[getVisibleMessages] Multiple roots (${rootMessages.length}), canonical root: ${canonicalRootId?.slice(0, 8)}`);
-      } else if (rootMessages.length === 1) {
-        canonicalRootId = rootMessages[0].id;
-      }
-      
-      // Helper function to find latest timestamp in a subtree
-      function findLatestInSubtree(root: Message, parentToChildren: Map<string, Message[]>): number {
-        let latest = 0;
-        const visited = new Set<string>();
-        
-        function visit(msg: Message) {
-          if (visited.has(msg.id)) return;
-          visited.add(msg.id);
-          
-          for (const branch of msg.branches) {
-            if (branch.createdAt) {
-              const time = new Date(branch.createdAt).getTime();
-              if (time > latest) latest = time;
-            }
-            // Visit children of this branch
-            const children = parentToChildren.get(branch.id) || [];
-            for (const child of children) visit(child);
-          }
-        }
-        
-        visit(root);
-        return latest;
-      }
-      
-      const visibleMessages: Message[] = [];
-      const branchPath: string[] = []; // Track the current conversation path (branch IDs)
-      
-      for (let i = 0; i < sortedMessages.length; i++) {
-        const message = sortedMessages[i];
-        const activeBranch = message.branches.find(b => b.id === message.activeBranchId);
-        
-        // console.log(`Message ${i}:`, message.id, 'activeBranchId:', message.activeBranchId, 
-        //             'branches:', message.branches.length, 
-        //             'activeBranch parentBranchId:', activeBranch?.parentBranchId);
-        
-        // Case 1: Active branch exists and is a root message
-        // Only accept the canonical root - skip others (handles multi-root conversations from looming)
-        if (activeBranch && (!activeBranch.parentBranchId || activeBranch.parentBranchId === 'root')) {
-          // Only accept if this is the canonical root (or if no canonical was determined)
-          if (branchPath.length === 0 && (!canonicalRootId || message.id === canonicalRootId)) {
-            visibleMessages.push(message);
-            branchPath.push(activeBranch.id);
-            // console.log('Added canonical root message:', message.id);
-          }
-          // Skip other roots - they're from different conversation branches
-          continue;
-        }
+      // Delegate to the shared pure helper so the path-resolution logic has a
+      // single source of truth (also reused by markdown export of arbitrary
+      // conversations). The cache wrapper around it stays here.
+      const visibleMessages = computeVisibleMessages(state.allMessages);
 
-        // Case 2: Active branch exists and continues from our current path
-        if (activeBranch && branchPath.includes(activeBranch.parentBranchId!)) {
-          // This message is a valid continuation
-          visibleMessages.push(message);
-          
-          // Find where in the path this branches from
-          const parentIndex = branchPath.indexOf(activeBranch.parentBranchId!);
-          
-          // Truncate the path after the parent and add this branch
-          branchPath.length = parentIndex + 1;
-          branchPath.push(activeBranch.id);
-          
-          // console.log('Message continues from branch at index', parentIndex, 'added branch:', activeBranch.id, 'branchPath now:', [...branchPath]);
-          continue;
-        }
-
-        // Case 3: Active branch doesn't exist or doesn't connect to our path
-        // Be strict: skip this message. Don't try to recover via other branches,
-        // as that can accidentally include orphaned/deleted branches from other roots.
-        // (This mirrors the import preview logic which is strict about following activeBranchId only)
-        if (!activeBranch) {
-          console.log('Skipping message with deleted active branch:', message.id);
-        }
-        // Message is from a different conversation path - skip it
-      }
-      
       // Update cache before returning
       visibleMessagesCache = {
         sourceVersion: messagesVersion,

--- a/deprecated-claude-app/frontend/src/utils/conversationMarkdown.ts
+++ b/deprecated-claude-app/frontend/src/utils/conversationMarkdown.ts
@@ -1,0 +1,175 @@
+/**
+ * Serialize a conversation to human-readable Markdown.
+ *
+ * This is a *view* over a conversation, intended as a readable companion to the
+ * full JSON export. It renders the active branch path only (the conversation as
+ * it actually played out); branch resolution and ordering are done by the
+ * shared helpers (`computeVisibleMessages` + `sortMessagesByTreeOrder`) before
+ * the messages reach this serializer, so nothing about ordering or branching is
+ * reimplemented here.
+ *
+ * Conventions:
+ *  - Each message becomes a `## Name · model` section.
+ *  - `thinking` content blocks are preserved but set apart in a `<details>`.
+ *  - Images / audio / attachments are referenced by a short placeholder rather
+ *    than inlined (the JSON export holds the actual bytes).
+ */
+import type {
+  Conversation,
+  Message,
+  MessageBranch,
+  Participant,
+  ContentBlock,
+  Attachment,
+} from '@deprecated-claude/shared';
+import { getActiveBranch } from '@deprecated-claude/shared';
+
+export interface ConversationMarkdownInput {
+  conversation: Pick<Conversation, 'title' | 'model'> & Partial<Conversation>;
+  participants: Participant[];
+  /** Messages already filtered to the visible active-branch path and ordered. */
+  messages: Message[];
+}
+
+function formatTimestamp(value: unknown): string | null {
+  if (!value) return null;
+  const date = value instanceof Date ? value : new Date(value as string);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toISOString();
+}
+
+/** Resolve the display name for the speaker of a branch. */
+function speakerName(
+  branch: MessageBranch,
+  participantsById: Map<string, Participant>,
+): string {
+  if (branch.participantId) {
+    const participant = participantsById.get(branch.participantId);
+    if (participant?.name) return participant.name;
+  }
+  switch (branch.role) {
+    case 'user':
+      return 'User';
+    case 'system':
+      return 'System';
+    default:
+      return 'Assistant';
+  }
+}
+
+/** Resolve the model label (branch overrides participant default). */
+function speakerModel(
+  branch: MessageBranch,
+  participantsById: Map<string, Participant>,
+): string | undefined {
+  if (branch.model) return branch.model;
+  if (branch.participantId) {
+    return participantsById.get(branch.participantId)?.model;
+  }
+  return undefined;
+}
+
+function renderContentBlock(block: ContentBlock): string {
+  switch (block.type) {
+    case 'text':
+      return block.text.trim();
+    case 'thinking': {
+      const thinking = block.thinking.trim();
+      if (!thinking) return '';
+      return `<details>\n<summary>thinking</summary>\n\n${thinking}\n\n</details>`;
+    }
+    case 'redacted_thinking':
+      return '> _[redacted thinking]_';
+    case 'image': {
+      const detail = block.revisedPrompt ? ` — ${block.revisedPrompt.trim()}` : '';
+      return `\`[image — ${block.mimeType}${detail}]\``;
+    }
+    case 'audio': {
+      const transcript = block.transcript?.trim();
+      const ref = `\`[audio — ${block.mimeType}]\``;
+      return transcript ? `${ref}\n\n> ${transcript.replace(/\n/g, '\n> ')}` : ref;
+    }
+    default:
+      return '';
+  }
+}
+
+function renderAttachment(att: Attachment): string {
+  const type = att.mimeType || att.fileType || 'file';
+  return `\`[attachment: ${att.fileName} — ${type}]\``;
+}
+
+/** Render the body of a single branch (content blocks or plain content). */
+function renderBranchBody(branch: MessageBranch): string {
+  const parts: string[] = [];
+
+  if (branch.contentBlocks && branch.contentBlocks.length > 0) {
+    for (const block of branch.contentBlocks) {
+      const rendered = renderContentBlock(block);
+      if (rendered) parts.push(rendered);
+    }
+  } else if (branch.content && branch.content.trim()) {
+    parts.push(branch.content.trim());
+  }
+
+  if (branch.attachments && branch.attachments.length > 0) {
+    parts.push(branch.attachments.map(renderAttachment).join('\n'));
+  }
+
+  return parts.join('\n\n').trim();
+}
+
+export function serializeConversationToMarkdown(
+  input: ConversationMarkdownInput,
+): string {
+  const { conversation, participants, messages } = input;
+  const participantsById = new Map(participants.map((p) => [p.id, p]));
+
+  const lines: string[] = [];
+
+  // Document header
+  const title = conversation.title?.trim() || 'Untitled conversation';
+  lines.push(`# ${title}`);
+
+  const meta: string[] = [];
+  if (conversation.model) meta.push(`Model: ${conversation.model}`);
+  meta.push(`Messages: ${messages.length}`);
+  const exportedAt = formatTimestamp(new Date());
+  if (exportedAt) meta.push(`Exported: ${exportedAt}`);
+  lines.push('');
+  lines.push(`_${meta.join(' · ')}_`);
+
+  if (conversation.systemPrompt && conversation.systemPrompt.trim()) {
+    lines.push('');
+    lines.push('## System prompt');
+    lines.push('');
+    lines.push(conversation.systemPrompt.trim());
+  }
+
+  for (const message of messages) {
+    const branch = getActiveBranch(message);
+    if (!branch) continue;
+
+    const name = speakerName(branch, participantsById);
+    const model = speakerModel(branch, participantsById);
+    const heading = model ? `${name} · ${model}` : name;
+
+    lines.push('');
+    lines.push('---');
+    lines.push('');
+    lines.push(`## ${heading}`);
+
+    const ts = formatTimestamp(branch.createdAt);
+    if (ts) {
+      lines.push('');
+      lines.push(`_${ts}_`);
+    }
+
+    const body = renderBranchBody(branch);
+    lines.push('');
+    lines.push(body || '_[empty message]_');
+  }
+
+  // Trailing newline for POSIX-friendly files
+  return lines.join('\n').trim() + '\n';
+}

--- a/deprecated-claude-app/frontend/src/views/ConversationView.vue
+++ b/deprecated-claude-app/frontend/src/views/ConversationView.vue
@@ -3609,6 +3609,18 @@ async function exportConversationMarkdown(id: string) {
         'Authorization': `Bearer ${localStorage.getItem('token')}`
       }
     });
+    if (!response.ok) {
+      let detail = '';
+      try {
+        detail = (await response.json())?.error || '';
+      } catch {
+        // response body was not JSON; leave detail empty
+      }
+      errorSnackbarMessage.value = 'Markdown export failed';
+      errorSnackbarDetails.value = detail || `Server returned ${response.status}`;
+      errorSnackbar.value = true;
+      return;
+    }
     const data = await response.json();
 
     const visibleMessages = computeVisibleMessages(data.messages || []);
@@ -3632,6 +3644,9 @@ async function exportConversationMarkdown(id: string) {
     URL.revokeObjectURL(url);
   } catch (error) {
     console.error('Markdown export failed:', error);
+    errorSnackbarMessage.value = 'Markdown export failed';
+    errorSnackbarDetails.value = error instanceof Error ? error.message : String(error);
+    errorSnackbar.value = true;
   }
 }
 

--- a/deprecated-claude-app/frontend/src/views/ConversationView.vue
+++ b/deprecated-claude-app/frontend/src/views/ConversationView.vue
@@ -203,7 +203,14 @@
                     <v-list-item
                       prepend-icon="mdi-download"
                       title="Export"
+                      subtitle="Full conversation as JSON"
                       @click="exportConversation(conversation.id)"
+                    />
+                    <v-list-item
+                      prepend-icon="mdi-language-markdown-outline"
+                      title="Export as Markdown"
+                      subtitle="Readable transcript (.md)"
+                      @click="exportConversationMarkdown(conversation.id)"
                     />
                     <v-list-item
                       prepend-icon="mdi-content-copy"
@@ -1268,7 +1275,7 @@
 import { ref, computed, onMounted, onBeforeUnmount, watch, nextTick } from 'vue';
 import { useRoute, useRouter, onBeforeRouteLeave } from 'vue-router';
 import { isEqual } from 'lodash-es';
-import { useStore } from '@/store';
+import { useStore, computeVisibleMessages } from '@/store';
 import { api } from '@/services/api';
 import type { Conversation, Message, Participant, Model, Bookmark, Persona, WsAttachment } from '@deprecated-claude/shared';
 import { UpdateParticipantSchema, getValidatedModelDefaults } from '@deprecated-claude/shared';
@@ -1288,6 +1295,7 @@ import MetricsDisplay from '@/components/MetricsDisplay.vue';
 import ModelPillBar from '@/components/ModelPillBar.vue';
 import AddParticipantDialog from '@/components/AddParticipantDialog.vue';
 import { getModelColor } from '@/utils/modelColors';
+import { serializeConversationToMarkdown } from '@/utils/conversationMarkdown';
 import { computeAuthenticity, type AuthenticityStatus } from '@/utils/authenticity';
 
 const route = useRoute();
@@ -3587,6 +3595,43 @@ async function exportConversation(id: string) {
     URL.revokeObjectURL(url);
   } catch (error) {
     console.error('Export failed:', error);
+  }
+}
+
+async function exportConversationMarkdown(id: string) {
+  try {
+    // Reuse the existing export endpoint (messages already tree-ordered by the
+    // backend), then resolve the visible active-branch path with the shared
+    // store helper and serialize to markdown. No conversation needs to be
+    // loaded in the store for this to work.
+    const response = await fetch(`/api/conversations/${id}/export`, {
+      headers: {
+        'Authorization': `Bearer ${localStorage.getItem('token')}`
+      }
+    });
+    const data = await response.json();
+
+    const visibleMessages = computeVisibleMessages(data.messages || []);
+    const markdown = serializeConversationToMarkdown({
+      conversation: data.conversation,
+      participants: data.participants || [],
+      messages: visibleMessages,
+    });
+
+    const safeTitle = (data.conversation?.title || `conversation-${id}`)
+      .replace(/[^\w\-. ]+/g, '_')
+      .trim()
+      .slice(0, 80) || `conversation-${id}`;
+
+    const blob = new Blob([markdown], { type: 'text/markdown' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `${safeTitle}.md`;
+    a.click();
+    URL.revokeObjectURL(url);
+  } catch (error) {
+    console.error('Markdown export failed:', error);
   }
 }
 


### PR DESCRIPTION
Add an "Export as Markdown" action alongside the existing JSON export. It fetches the conversation via the existing /export endpoint (messages already tree-ordered by the backend), resolves the visible active-branch path, and serializes a readable transcript.

- Extract getVisibleMessages' path-resolution into a pure, exported computeVisibleMessages(messages) so it can be reused for a conversation that is not the currently-loaded one. The store method now wraps it with its existing cache; behavior is unchanged.
- Add utils/conversationMarkdown.ts: a pure serializer. Active path only; thinking blocks preserved in <details>; images/audio/attachments are referenced by a short placeholder rather than inlined (the JSON export holds the bytes).
- Add the menu item + handler in ConversationView.