### PR TITLE
Secure provider credential setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 .env.*.local
 **/.env
 **/.env.local
+**/.env.tmp-*
 deprecated-claude-app/frontend/node_modules/**
 deprecated-claude-app/shared/dist/**
 .idea/**

--- a/deprecated-claude-app/README.md
+++ b/deprecated-claude-app/README.md
@@ -43,6 +43,11 @@ cp .env.example .env
 # Edit .env with your configuration
 ```
 
+To enter the four optional provider fallback credentials interactively, run
+`backend/config/setup-config.sh` from the `deprecated-claude-app` directory.
+The helper writes only to the ignored `backend/.env` file, preserves unrelated
+settings, and restricts the resulting file to the current user.
+
 Required environment variables:
 - `JWT_SECRET`: Secret key for authentication
 - `AWS_REGION`: AWS region with Bedrock access (default: us-east-1)

--- a/deprecated-claude-app/backend/config/setup-config.sh
+++ b/deprecated-claude-app/backend/config/setup-config.sh
@@ -1,58 +1,55 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-# Script to help set up config.json with real API keys
-# Run this script and it will prompt for API keys and update config.json
+# Configure optional provider fallback credentials without putting secrets in
+# command arguments. User-scoped keys should normally be added through the UI.
 
-CONFIG_FILE="config.json"
+set -euo pipefail
 
-echo "Setting up API keys in config.json"
-echo "=================================="
-echo ""
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+env_file="${1:-"$script_dir/../.env"}"
+anthropic_key=''
+openrouter_key=''
+aws_access_key=''
+aws_secret_key=''
 
-# Anthropic API Key
-echo -n "Enter your Anthropic API key (sk-ant-...): "
-read -s ANTHROPIC_KEY
-echo ""
-
-# OpenRouter API Key
-echo -n "Enter your OpenRouter API key (sk-or-...): "
-read -s OPENROUTER_KEY
-echo ""
-
-# AWS Credentials
-echo -n "Enter your AWS Access Key ID: "
-read AWS_ACCESS_KEY
-echo -n "Enter your AWS Secret Access Key: "
-read -s AWS_SECRET_KEY
-echo ""
-
-# Update config.json with the real keys
-if [[ "$OSTYPE" == "darwin"* ]]; then
-    # macOS
-    sed -i '' "s/sk-ant-api03-YOUR-KEY-HERE/$ANTHROPIC_KEY/g" "$CONFIG_FILE"
-    sed -i '' "s/sk-or-v1-YOUR-KEY-HERE/$OPENROUTER_KEY/g" "$CONFIG_FILE"
-    sed -i '' "s/AKIAIOSFODNN7EXAMPLE/$AWS_ACCESS_KEY/g" "$CONFIG_FILE"
-    sed -i '' "s|wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY|$AWS_SECRET_KEY|g" "$CONFIG_FILE"
-else
-    # Linux
-    sed -i "s/sk-ant-api03-YOUR-KEY-HERE/$ANTHROPIC_KEY/g" "$CONFIG_FILE"
-    sed -i "s/sk-or-v1-YOUR-KEY-HERE/$OPENROUTER_KEY/g" "$CONFIG_FILE"
-    sed -i "s/AKIAIOSFODNN7EXAMPLE/$AWS_ACCESS_KEY/g" "$CONFIG_FILE"
-    sed -i "s|wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY|$AWS_SECRET_KEY|g" "$CONFIG_FILE"
+if (( $# > 1 )); then
+    printf 'usage: %s [environment-file]\n' "$0" >&2
+    exit 2
 fi
 
-echo ""
-echo "✅ Config file updated with API keys!"
-echo ""
-echo "Pricing Summary:"
-echo "==============="
-echo ""
-echo "Haiku models: FREE for all users (100% subsidized)"
-echo "Sonnet models: ~83% subsidized ($0.50/$2.50 vs $3/$15)"
-echo "Opus models: 80% subsidized ($3/$15 vs $15/$75)"
-echo "GPT-3.5: FREE for all users"
-echo "GPT-4: 80% subsidized ($2/$6 vs $10/$30)"
-echo "Llama models: FREE for all users"
-echo ""
-echo "Note: This configuration gives users heavily subsidized access to AI models."
-echo "Company absorbs most of the API costs to make AI accessible to everyone."
+read_secret() {
+    local prompt="$1"
+    local destination="$2"
+    local value
+
+    printf '%s' "$prompt" >&2
+    IFS= read -r -s value
+    printf '\n' >&2
+    printf -v "$destination" '%s' "$value"
+}
+
+read_secret 'Enter your Anthropic API key (sk-ant-...): ' anthropic_key
+read_secret 'Enter your OpenRouter API key (sk-or-...): ' openrouter_key
+read_secret 'Enter your AWS Access Key ID: ' aws_access_key
+read_secret 'Enter your AWS Secret Access Key: ' aws_secret_key
+
+printf '%s\n' \
+    "$anthropic_key" \
+    "$openrouter_key" \
+    "$aws_access_key" \
+    "$aws_secret_key" |
+    node "$script_dir/update-provider-env.mjs" "$env_file"
+
+unset anthropic_key openrouter_key aws_access_key aws_secret_key
+
+printf '\nProvider fallback credentials updated in %s.\n' "$env_file"
+printf 'The file is owner-readable only; do not commit or share it.\n\n'
+printf 'Pricing Summary:\n'
+printf '===============\n\n'
+printf 'Haiku models: FREE for all users (100%% subsidized)\n'
+printf '%s\n' "Sonnet models: ~83% subsidized (\$0.50/\$2.50 vs \$3/\$15)"
+printf '%s\n' "Opus models: 80% subsidized (\$3/\$15 vs \$15/\$75)"
+printf 'GPT-3.5: FREE for all users\n'
+printf '%s\n' "GPT-4: 80% subsidized (\$2/\$6 vs \$10/\$30)"
+printf 'Llama models: FREE for all users\n\n'
+printf 'Review providerCost and billedCost in the active config before billing users.\n'

--- a/deprecated-claude-app/backend/config/setup-config.test.sh
+++ b/deprecated-claude-app/backend/config/setup-config.test.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+test_dir="$(mktemp -d "${TMPDIR:-/tmp}/setup-config-test.XXXXXX")"
+trap 'rm -rf -- "${test_dir:?}"' EXIT
+
+target="$test_dir/.env"
+cp "$script_dir/../env.example" "$target"
+chmod 0644 "$target"
+
+output="$(
+    printf '%s\n' \
+        'sk-ant-test/with+slash=' \
+        'sk-or-test/with+slash=' \
+        'AKIATESTACCESS1234' \
+        'fake/secret+value=123' |
+        bash "$script_dir/setup-config.sh" "$target" 2>/dev/null
+)"
+
+expected_lines=(
+    'ANTHROPIC_API_KEY=sk-ant-test/with+slash='
+    'OPENROUTER_API_KEY=sk-or-test/with+slash='
+    'AWS_ACCESS_KEY_ID=AKIATESTACCESS1234'
+    'AWS_SECRET_ACCESS_KEY=fake/secret+value=123'
+)
+for expected in "${expected_lines[@]}"; do
+    if ! grep -Fqx -- "$expected" "$target"; then
+        printf 'missing exact environment line: %s\n' "$expected" >&2
+        exit 1
+    fi
+done
+
+if ! grep -Fqx -- 'FRONTEND_URL=http://localhost:5173' "$target"; then
+    printf 'an unrelated environment setting was not preserved\n' >&2
+    exit 1
+fi
+
+for expected in \
+    "Sonnet models: ~83% subsidized (\$0.50/\$2.50 vs \$3/\$15)" \
+    "Opus models: 80% subsidized (\$3/\$15 vs \$15/\$75)" \
+    "GPT-4: 80% subsidized (\$2/\$6 vs \$10/\$30)"; do
+    if ! grep -Fqx -- "$expected" <<< "$output"; then
+        printf 'missing literal pricing line: %s\n' "$expected" >&2
+        exit 1
+    fi
+done
+
+if [[ "$(uname -s)" == 'Darwin' ]]; then
+    file_mode="$(stat -f '%Lp' "$target")"
+else
+    file_mode="$(stat -c '%a' "$target")"
+fi
+if [[ "$file_mode" != '600' ]]; then
+    printf 'environment file mode is %s, expected 600\n' "$file_mode" >&2
+    exit 1
+fi
+
+if [[ -e "$test_dir/config.json" ]]; then
+    printf 'obsolete config.json credential file was created\n' >&2
+    exit 1
+fi
+
+symlink_target="$test_dir/real.env"
+symlink_path="$test_dir/symlink.env"
+printf 'PRESERVE=true\n' > "$symlink_target"
+ln -s "$symlink_target" "$symlink_path"
+if printf '%s\n' \
+    'sk-ant-test-value' \
+    'sk-or-test-value' \
+    'AKIATESTACCESS1234' \
+    'fake/secret+value=123' |
+    bash "$script_dir/setup-config.sh" "$symlink_path" >/dev/null 2>&1; then
+    printf 'setup unexpectedly accepted a symlink target\n' >&2
+    exit 1
+fi
+if ! grep -Fqx -- 'PRESERVE=true' "$symlink_target"; then
+    printf 'symlink target was modified\n' >&2
+    exit 1
+fi
+
+printf 'setup-config security tests passed\n'

--- a/deprecated-claude-app/backend/config/update-provider-env.mjs
+++ b/deprecated-claude-app/backend/config/update-provider-env.mjs
@@ -1,0 +1,147 @@
+#!/usr/bin/env node
+
+import { randomUUID } from 'node:crypto';
+import {
+  constants,
+  chmod,
+  mkdir,
+  open,
+  rename,
+  rm,
+} from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+
+const credentialNames = [
+  'ANTHROPIC_API_KEY',
+  'OPENROUTER_API_KEY',
+  'AWS_ACCESS_KEY_ID',
+  'AWS_SECRET_ACCESS_KEY',
+];
+const credentialPatterns = [
+  /^sk-ant-[A-Za-z0-9_./+=:-]+$/,
+  /^sk-or-[A-Za-z0-9_./+=:-]+$/,
+  /^[A-Za-z0-9_./+=:-]+$/,
+  /^[A-Za-z0-9_./+=:-]+$/,
+];
+
+function fail(message) {
+  process.stderr.write(`${message}\n`);
+  process.exitCode = 1;
+}
+
+async function readStdin() {
+  const chunks = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(chunk);
+  }
+  return Buffer.concat(chunks).toString('utf8');
+}
+
+function parseCredentials(input) {
+  const values = input.endsWith('\n')
+    ? input.slice(0, -1).split('\n')
+    : input.split('\n');
+
+  if (values.length !== credentialNames.length) {
+    throw new Error('Expected exactly four newline-delimited credentials');
+  }
+
+  values.forEach((value, index) => {
+    if (
+      value.length < 8
+      || value.length > 4096
+      || !credentialPatterns[index].test(value)
+    ) {
+      throw new Error(`Invalid ${credentialNames[index]} value`);
+    }
+  });
+  return values;
+}
+
+function updateEnvironment(existing, values) {
+  const replacements = new Map(
+    credentialNames.map((name, index) => [name, `${name}=${values[index]}`]),
+  );
+  const seen = new Set();
+  const lines = existing ? existing.replace(/\r\n/g, '\n').split('\n') : [];
+  const updated = [];
+
+  for (const line of lines) {
+    const match = /^([A-Z][A-Z0-9_]*)=/.exec(line);
+    const name = match?.[1];
+    if (!name || !replacements.has(name)) {
+      updated.push(line);
+      continue;
+    }
+    if (!seen.has(name)) {
+      updated.push(replacements.get(name));
+      seen.add(name);
+    }
+  }
+
+  for (const name of credentialNames) {
+    if (!seen.has(name)) {
+      updated.push(replacements.get(name));
+    }
+  }
+
+  while (updated.length > 0 && updated.at(-1) === '') {
+    updated.pop();
+  }
+  return `${updated.join('\n')}\n`;
+}
+
+async function main() {
+  if (process.argv.length !== 3) {
+    throw new Error('usage: update-provider-env.mjs <environment-file>');
+  }
+
+  const target = resolve(process.argv[2]);
+  const parent = dirname(target);
+  await mkdir(parent, { recursive: true, mode: 0o700 });
+
+  let existing = '';
+  let existingHandle;
+  try {
+    existingHandle = await open(
+      target,
+      constants.O_RDONLY
+        | (constants.O_NOFOLLOW ?? 0)
+        | (constants.O_NONBLOCK ?? 0),
+    );
+    const targetStat = await existingHandle.stat();
+    if (!targetStat.isFile()) {
+      throw new Error('Environment target must be a regular file');
+    }
+    existing = await existingHandle.readFile({ encoding: 'utf8' });
+  } catch (error) {
+    if (error?.code !== 'ENOENT') {
+      throw error;
+    }
+  } finally {
+    await existingHandle?.close();
+  }
+
+  const credentials = parseCredentials(await readStdin());
+  const content = updateEnvironment(existing, credentials);
+  const temporary = `${target}.tmp-${process.pid}-${randomUUID()}`;
+  let handle;
+
+  try {
+    handle = await open(temporary, 'wx', 0o600);
+    await handle.writeFile(content, { encoding: 'utf8' });
+    await handle.sync();
+    await handle.close();
+    handle = undefined;
+    await rename(temporary, target);
+    await chmod(target, 0o600);
+  } catch (error) {
+    await handle?.close();
+    await rm(temporary, { force: true });
+    throw error;
+  }
+}
+
+main().catch((error) => {
+  fail(error instanceof Error ? error.message : 'Credential update failed');
+});

--- a/deprecated-claude-app/package.json
+++ b/deprecated-claude-app/package.json
@@ -13,7 +13,7 @@
     "dev:frontend": "npm run dev -w frontend",
     "build": "npm run build -w shared && npm run build -w backend && npm run build -w frontend",
     "typecheck": "npm run typecheck -w shared && npm run typecheck -w backend",
-    "test": "npm run test --workspaces"
+    "test": "bash backend/config/setup-config.test.sh && npm run test --workspaces --if-present"
   },
   "devDependencies": {
     "concurrently": "^8.2.2"


### PR DESCRIPTION
Fixes #136

## What changed

- replaces shell interpolation and `sed`-based provider configuration with a literal-data Node updater
- reads values from standard input instead of command arguments
- performs atomic mode-0600 environment-file replacement
- rejects symlink targets and preserves unrelated configuration safely
- treats pricing values literally and adds shell/Node regression tests

## Root cause and impact

Provider credentials and pricing values were inserted through shell-sensitive text rewriting. Metacharacters, delimiters, or a hostile filesystem target could corrupt configuration, disclose values through process arguments, or redirect writes.

The new updater treats all supplied values as data and writes the credential file atomically with owner-only permissions.

## Verification

- `npm test --prefix deprecated-claude-app`
- `shellcheck deprecated-claude-app/backend/config/setup-config.sh deprecated-claude-app/backend/config/setup-config.test.sh`
- `node --check deprecated-claude-app/backend/config/update-provider-env.mjs`
- `git diff HEAD^ --check`

All commands exited zero at commit `4f335f0943ca215c48bd0c2d82041133f477669e`. The repository policy gate passed with no violations or warnings.
