### PR TITLE
Surface refusal stop_details (classifier category + explanation) in error notices; fix .env load order

### DIFF
--- a/deprecated-claude-app/backend/src/index.ts
+++ b/deprecated-claude-app/backend/src/index.ts
@@ -1,3 +1,10 @@
+// Load .env before any other import executes. Several modules (e.g.
+// middleware/auth.ts reading JWT_SECRET) validate environment variables at
+// module scope, which runs during import resolution — before the
+// dotenv.config() call further down in this file. Without this first-line
+// side-effect import, a JWT_SECRET that lives only in .env is invisible at
+// that point and startup fails.
+import 'dotenv/config';
 import express from 'express';
 import compression from 'compression';
 import { clearOpenRouterLog } from './utils/openrouterLogger.js';

--- a/deprecated-claude-app/backend/src/services/anthropic.ts
+++ b/deprecated-claude-app/backend/src/services/anthropic.ts
@@ -264,6 +264,13 @@ export class AnthropicService {
       const stream = await this.client.messages.create(requestParams) as any;
 
       let stopReason: string | undefined;
+      // Structured refusal details (stop_details) — sent by the API alongside
+      // stop_reason: 'refusal'. Shape: { type: 'refusal', category, explanation }.
+      // category (e.g. 'cyber' | 'bio' | 'reasoning_extraction' | 'frontier_llm')
+      // identifies an external safety-classifier intervention; category: null
+      // means the model itself declined. Not in SDK types at ^0.60.0, so read
+      // via `as any`.
+      let stopDetails: { category?: string | null; explanation?: string | null } | undefined;
       let usage: any = {};
       let cacheMetrics = {
         cacheCreationInputTokens: 0,
@@ -368,6 +375,11 @@ export class AnthropicService {
             if (chunk.delta?.stop_sequence) {
               console.log(`[Anthropic API] Stop sequence: "${chunk.delta.stop_sequence}"`);
             }
+            const rawStopDetails = (chunk.delta as any)?.stop_details;
+            if (rawStopDetails) {
+              stopDetails = rawStopDetails;
+              console.log(`[Anthropic API] Stop details:`, JSON.stringify(rawStopDetails));
+            }
           }
           if (chunk.usage) {
             // MERGE, not replace. `message_delta.usage` typically carries only
@@ -417,9 +429,33 @@ export class AnthropicService {
           if (stopReason && !TERMINATED_NORMALLY.has(stopReason)) {
             let notice: string;
             if (stopReason === 'refusal') {
-              notice = hasVisibleText
-                ? '⚠️ Response cut off by the model\'s safety filter (`stop_reason: refusal`) — an API-side stop, not a max_tokens truncation. Retrying or rephrasing may get past it.'
-                : '⚠️ Response withheld by the model\'s safety filter (`stop_reason: refusal`). The model reasoned but its answer was not surfaced. Try rephrasing or retrying.';
+              // stop_reason: refusal covers two distinct events, distinguished
+              // by stop_details.category:
+              //  - category present (cyber / bio / reasoning_extraction /
+              //    frontier_llm / ...) → an external safety classifier stopped
+              //    the response; the model did not choose this.
+              //  - category null/absent → the refusal came from the model side.
+              // Surfacing which one it was (plus the API's own explanation)
+              // tells the user what actually happened instead of a generic
+              // "refusal".
+              const category = stopDetails?.category ?? null;
+              const explanation = stopDetails?.explanation ?? null;
+              const parts: string[] = [];
+              parts.push(hasVisibleText
+                ? '⚠️ Response cut off by a safety stop (`stop_reason: refusal`) — an API-side stop, not a max_tokens truncation.'
+                : '⚠️ Response withheld by a safety stop (`stop_reason: refusal`). The model may have reasoned, but its answer was not surfaced.');
+              if (category) {
+                parts.push(`An external safety classifier intervened (category: \`${category}\`) — this was triggered by the flagged topic area, not by the model declining.`);
+                parts.push('Rephrasing away from the flagged territory is more likely to help than a plain retry.');
+              } else if (stopDetails) {
+                parts.push('No classifier category was reported (`stop_details.category: null`), which usually means the refusal came from the model rather than an external classifier. Retrying or rephrasing may help.');
+              } else {
+                parts.push('The API sent no further detail (`stop_details` absent — older models don\'t report it). Retrying or rephrasing may help.');
+              }
+              if (explanation) {
+                parts.push(`API explanation: ${explanation}`);
+              }
+              notice = parts.join(' ');
             } else if (stopReason === 'max_tokens') {
               notice = hasVisibleText
                 ? '⚠️ Output truncated at the `max_tokens` limit. Raise max_tokens, or lower the thinking budget/effort.'


### PR DESCRIPTION
## What

Two backend fixes:

**1. Refusal notices now show what actually happened** (`e562683`)

Previously every `stop_reason: refusal` rendered as one generic notice, so users couldn't tell an external safety-classifier intervention from the model itself declining — or see what was flagged.

The Anthropic API reports refusal details in `message_delta` via a `stop_details` object: `category` (`cyber` / `bio` / `reasoning_extraction` / `frontier_llm` / `null`) and `explanation`. A present category means an external classifier stopped the response; `category: null` means the refusal came from the model side.

The streaming handler now captures `stop_details` alongside `stop_reason`, and the injected display-only notice distinguishes three cases:
- **classifier intervention** — names the category, notes it was not the model declining, suggests rephrasing away from the flagged territory
- **`category: null`** — model-side refusal, plain retry/rephrase suggestion
- **`stop_details` absent** — older models that don't report it

The API's own `explanation` is appended verbatim when present. (SDK is at ^0.60.0, which predates `stop_details` typings, so it's read via `as any`; wire fields pass through the SDK untouched.)

**2. Backend crashed on startup when `JWT_SECRET` lived only in `.env`** (`0ccfec0`)

`middleware/auth.ts` validates `JWT_SECRET` at module scope, which executes during import resolution — before the `dotenv.config()` call in `index.ts` body ever runs. Fixed with a first-line side-effect `import 'dotenv/config'`.

## Testing

- Synthetic-stream tests of all four paths: classifier refusal mid-stream (partial text + category + explanation), model-side refusal (`category: null`), refusal with no `stop_details`, and normal `end_turn` (no notice injected, no regression).
- `tsc --noEmit` clean; backend boots from `.env` alone; verified manually in the running app.
- One caveat flagged in the commit: `stop_details` arriving inside `message_delta` matches the API docs, and a log line (`[Anthropic API] Stop details:`) was added so the first live refusal confirms it on the wire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)