### PR TITLE
fix(db): replay message_restored / message_branch_restored — restored messages vanished on restart

### DIFF
--- a/deprecated-claude-app/backend/src/database/index.ts
+++ b/deprecated-claude-app/backend/src/database/index.ts
@@ -136,6 +136,11 @@ export class Database {
   private userGrantTotals: Map<string, Map<string, number>> = new Map();
   private invites: Map<string, Invite> = new Map(); // code -> Invite
 
+  // Messages removed by message_deleted replay, kept so a later
+  // message_branch_restored replay can resurrect the container with its
+  // original order (mirrors the runtime restoreBranch event-history lookup).
+  private replayDeletedMessages: Map<string, Message> = new Map();
+
   private eventStore: EventStore;
   // per user, contains conversation metadata events and participant events
   private userEventStore: BulkEventStore;
@@ -1084,6 +1089,14 @@ export class Database {
           }
         }
 
+        // Stash the deleted message so a later message_branch_restored replay
+        // can resurrect the container with its original order (mirrors the
+        // runtime restoreBranch path, which looks the original message up in
+        // the event history).
+        if (message) {
+          this.replayDeletedMessages.set(messageId, message);
+        }
+
         this.messages.delete(messageId);
         const convMessages = this.conversationMessages.get(conversationId);
         if (convMessages) {
@@ -1094,7 +1107,94 @@ export class Database {
         }
         break;
       }
-      
+
+      case 'message_restored': {
+        // Undo of message_deleted (see restoreMessage). Without this replay
+        // handler, restored messages existed only in the running process's
+        // memory and silently vanished on the next backend restart — leaving
+        // child branches pointing at branches of a missing message, which
+        // scrambled visible-path linearization, tree-map clicks, and exports.
+        const restored = event.data.message;
+        if (!restored?.id) break;
+
+        const message = {
+          ...restored,
+          createdAt: new Date(restored.createdAt || event.timestamp),
+          branches: (restored.branches || []).map((branch: any) => ({
+            ...branch,
+            createdAt: new Date(branch.createdAt || event.timestamp)
+          }))
+        };
+        this.messages.set(message.id, message);
+
+        // Re-insert into the conversation's message list at the position its
+        // order dictates (mirrors restoreMessage) — a plain push would put it
+        // after messages created later than the restore.
+        const restoredConvMessages = this.conversationMessages.get(message.conversationId) || [];
+        if (!restoredConvMessages.includes(message.id)) {
+          const insertIndex = restoredConvMessages.findIndex((id: string) => {
+            const m = this.messages.get(id);
+            return m && m.order > message.order;
+          });
+          if (insertIndex === -1) {
+            restoredConvMessages.push(message.id);
+          } else {
+            restoredConvMessages.splice(insertIndex, 0, message.id);
+          }
+        }
+        this.conversationMessages.set(message.conversationId, restoredConvMessages);
+        break;
+      }
+
+      case 'message_branch_restored': {
+        // Undo of message_branch_deleted (see restoreBranch). Same replay hole
+        // as message_restored above.
+        const { messageId: restoredBranchMsgId, conversationId: restoredBranchConvId, branch: restoredBranchData } = event.data;
+        if (!restoredBranchMsgId || !restoredBranchData?.id) break;
+
+        const restoredBranch = {
+          ...restoredBranchData,
+          createdAt: new Date(restoredBranchData.createdAt || event.timestamp)
+        };
+
+        const existingMsg = this.messages.get(restoredBranchMsgId);
+        if (existingMsg) {
+          if (!existingMsg.branches.some(b => b.id === restoredBranch.id)) {
+            this.messages.set(restoredBranchMsgId, {
+              ...existingMsg,
+              branches: [...existingMsg.branches, restoredBranch]
+            });
+          }
+        } else {
+          // The container message was deleted (deleting the only branch
+          // deletes the message). Resurrect it from the stash captured during
+          // message_deleted replay, with only the restored branch (mirrors
+          // the runtime restoreBranch missing-message path).
+          const stashed = this.replayDeletedMessages.get(restoredBranchMsgId);
+          if (!stashed) break; // nothing to resurrect from — skip, as before
+          const resurrected = {
+            ...stashed,
+            branches: [restoredBranch]
+          };
+          this.messages.set(restoredBranchMsgId, resurrected);
+
+          const branchConvMessages = this.conversationMessages.get(restoredBranchConvId) || [];
+          if (!branchConvMessages.includes(restoredBranchMsgId)) {
+            const insertIndex = branchConvMessages.findIndex((id: string) => {
+              const m = this.messages.get(id);
+              return m && m.order > resurrected.order;
+            });
+            if (insertIndex === -1) {
+              branchConvMessages.push(restoredBranchMsgId);
+            } else {
+              branchConvMessages.splice(insertIndex, 0, restoredBranchMsgId);
+            }
+          }
+          this.conversationMessages.set(restoredBranchConvId, branchConvMessages);
+        }
+        break;
+      }
+
       case 'message_order_changed': {
         const { messageId, newOrder } = event.data;
         const message = this.messages.get(messageId);


### PR DESCRIPTION
## Root cause of the prod tree breakage after the v1.11.0 deploy

`message_restored` and `message_branch_restored` (introduced 2025-12-23, `6e59852`) never had replay handlers in the event-sourced DB. Restoring a deleted message existed **only in the running process's memory**; the next restart rebuilt state from the event log and silently dropped every restored message.

Consequences in affected conversations:
- child branches point at branches of a message missing from rebuilt state,
- visible-path linearization goes wrong (displayed message sequence),
- tree-map clicks activate wrong targets,
- markdown export ordering is wrong,
- while the tree map itself still looks ~correct (remaining edges intact).

This explains the confusing correlation: **the v1.11.0 deploy didn't contain the bug — it was the first backend restart since v1.10.0 (July 24)**, so every conversation that used delete+restore (undo) since then degraded at once, with no code change touching them. Any deploy would have triggered it.

## No data was lost

The full message payload rides inside the `message_restored` event. With this fix, the next restart replays those events correctly and affected conversations **self-heal** — no manual repair needed.

## Fix

- `message_restored`: re-insert the message at its `order` position (mirrors `restoreMessage`).
- `message_branch_restored`: re-attach the branch; if the container message was deleted (only-branch deletion), resurrect it from a stash captured during `message_deleted` replay (mirrors `restoreBranch`'s event-history lookup).
- Like the runtime restore paths, the new handlers deliberately do not adjust `totalBranchCount` — kept symmetric with runtime so replayed state matches what the running process had.

## Testing

- Database-level reproduction (delete message → restore → new `Database` over the same data dir): **before** the fix the restored message vanished on replay (`[first, third]`); **after**, state is identical across restart (`[first, second, third]`).
- Same for the only-branch delete → branch restore path.
- `tsc --noEmit` clean; full backend boot over a real data dir (incl. a 366-message imported conversation) replays without errors.

## Related known hole (not addressed here)

`message_imported_raw` replay has a documented similar gap ("this is why imported messages disappear after restart"). Separate issue; this PR doesn't touch it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)